### PR TITLE
fix bug of filters not being removed from the context menu

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -2578,8 +2578,9 @@
             // if we receive an empty value for a filter, delete it
             if (column && value === '') {
                 delete columnFilters[column];
+            } else {
+                columnFilters[column] = value;
             }
-            columnFilters[column] = value;
             Object.keys(columnFilters).forEach(function (filter) {
                 var header = getHeaderByName(column);
                 if (!header) {


### PR DESCRIPTION
When i removed a filter, the visual indicators, and the entry in the context menu were not removed correctly