### PR TITLE
Fix setters for frozenRow and frozenColumn

### DIFF
--- a/lib/intf.js
+++ b/lib/intf.js
@@ -817,7 +817,7 @@ define([], function () {
                 if (isNaN(val)) {
                     throw new TypeError('Expected value for frozenRow to be a number.');
                 }
-                if (self.visibleRows.length > val) {
+                if (self.visibleRows.length < val) {
                     throw new RangeError('Cannot set a value larger than the number of visible rows.');
                 }
                 self.frozenRow = val;
@@ -831,7 +831,7 @@ define([], function () {
                 if (isNaN(val)) {
                     throw new TypeError('Expected value for frozenRow to be a number.');
                 }
-                if (self.getVisibleSchema().length > val) {
+                if (self.getVisibleSchema().length < val) {
                     throw new RangeError('Cannot set a value larger than the number of visible columns.');
                 }
                 self.frozenColumn = val;


### PR DESCRIPTION
Setters for frozenRow and frozenColumn properties should throw an error if the number of visible rows is less than the frozen row's index value.