### PR TITLE
fixed bad doc syntax

### DIFF
--- a/lib/intf.js
+++ b/lib/intf.js
@@ -965,7 +965,6 @@ define([], function () {
          * @memberof canvasDatagrid
          * @name getDataTypes
          * @method
-         * @returns array List of registered MIME types.
          */
         self.intf.getTypes = function () {
             return Object.keys(self.parsers);


### PR DESCRIPTION
Bad syntax in a doc property caused the doc site to hang.
