### PR TITLE
Remove scrollTop = 0 from setters.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -720,6 +720,11 @@ define([], function () {
                 tIndex = cr[self.dragMode].indexOf(self.reorderTarget[i]);
                 cr[self.dragMode].splice(oIndex, 1);
                 cr[self.dragMode].splice(tIndex, 0, self.reorderObject[i]);
+                if(self.dragMode === 'column-reorder') {
+                  self.orders.columns = cr[self.dragMode];
+                } else {
+                  self.orders.rows = cr[self.dragMode];
+                }
                 self.resize();
                 self.setStorageData();
             }

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1173,9 +1173,9 @@ define([], function () {
                     return sHeight;
                 },
                 set: function (value) {
-                    if (scrollHeight < value) {
-                        scrollTop = 0;
-                    }
+                    // if (scrollHeight < value) {
+                    //     scrollTop = 0;
+                    // }
                     sHeight = value;
                 }
             });
@@ -1207,9 +1207,9 @@ define([], function () {
                     if (scrollTop > value) {
                         scrollTop = Math.max(value, 0);
                     }
-                    if (scrollHeight < sHeight) {
-                        scrollTop = 0;
-                    }
+                    // if (scrollHeight < sHeight) {
+                    //     scrollTop = 0;
+                    // }
                     scrollHeight = value;
                 }
             });

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1173,9 +1173,6 @@ define([], function () {
                     return sHeight;
                 },
                 set: function (value) {
-                    // if (scrollHeight < value) {
-                    //     scrollTop = 0;
-                    // }
                     sHeight = value;
                 }
             });
@@ -1207,9 +1204,6 @@ define([], function () {
                     if (scrollTop > value) {
                         scrollTop = Math.max(value, 0);
                     }
-                    // if (scrollHeight < sHeight) {
-                    //     scrollTop = 0;
-                    // }
                     scrollHeight = value;
                 }
             });


### PR DESCRIPTION
Fixes issue #202 

Changes proposed in this pull request:

- Remove the check against the scrollHeight that resets the scrollTop to 0.
