### PR TITLE
Check for NaN on keypress navigation.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1020,13 +1020,13 @@ define([], function () {
                 self.draw(true);
                 return;
             }
-            if (x < 0) {
+            if (x < 0 || Number.isNaN(x)) {
                 x = adjacentCells.first;
             }
             if (y > last) {
                 y = last;
             }
-            if (y < 0) {
+            if (y < 0 || Number.isNaN(y)) {
                 y = 0;
             }
             if (x > cols) {
@@ -1042,7 +1042,11 @@ define([], function () {
                 self.draw(true);
             }
             if (x !== self.activeCell.columnIndex || y !== self.activeCell.rowIndex) {
-                self.scrollIntoView(x !== self.activeCell.columnIndex ? x : undefined, y !== self.activeCell.rowIndex ? y : undefined);
+                self.scrollIntoView(
+                  x !== self.activeCell.columnIndex ? x : undefined,
+                  y !== self.activeCell.rowIndex && !Number.isNaN(y) ? y : undefined
+                );
+
                 self.setActiveCell(x, y);
                 if (!e.shiftKey && self.attributes.selectionFollowsActiveCell) {
                     if (!ctrl) {


### PR DESCRIPTION
When a grid has extra gray space at the bottom, a user could click in that region then attempt to keyboard navigate.  This caused the rowIndex to be NaN which was throwing an error.
