### PR TITLE
Added cell to endfreezemove event.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -786,7 +786,7 @@ define([], function () {
             document.body.removeEventListener('mousemove', self.freezeMove, false);
             document.body.removeEventListener('mouseup', self.stopFreezeMove, false);
             self.freezeMarkerPosition = undefined;
-            if (self.dispatchEvent('endfreezemove', {NativeEvent: e})) {
+            if (self.dispatchEvent('endfreezemove', {NativeEvent: e, cell: self.currentCell})) {
                 self.frozenRow = self.startFreezeMove.x;
                 self.frozenColumn = self.startFreezeMove.y;
                 self.draw(true);


### PR DESCRIPTION
Fixes issue #.

Changes proposed in this pull request:

- Add cell to endfreezemove event. Allows for current column to be used to replicate recent changes to grid freeze bar.
