### PR TITLE
SetDataFilterApply

### DIFF
--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1083,8 +1083,8 @@ define([], function () {
                 }
                 // set the unfiltered/sorted data array
                 self.originalData = data;
-                //TODO apply filter to incoming dataset
-                self.data = self.originalData;
+                // apply filter to incoming dataset
+                self.applyFilter();
                 // empty data was set
                 if (!self.schema && (self.data || []).length === 0) {
                     self.tempSchema = [{name: ''}];

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -176,6 +176,21 @@ define([], function () {
             }
             return f;
         };
+        self.applyFilter = function () {
+            self.refreshFromOrigialData();
+            Object.keys(self.columnFilters).forEach(function (filter) {
+                var header = self.getHeaderByName(filter);
+                if (!header) {
+                    return;
+                }
+                self.currentFilter = header.filter || self.filter(header.type || 'string');
+                self.data = self.data.filter(function (row) {
+                    return self.currentFilter(row[filter], self.columnFilters[filter]);
+                });
+            });
+            self.resize();
+            self.draw(true);
+        };
         self.getBestGuessDataType = function (columnName, data) {
             var t, x, l = data.length;
             for (x = 0; x < l; x += 1) {

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -181,21 +181,6 @@ define([], function () {
          * @param {string} value The value to filter for.
          */
         self.setFilter = function (column, value) {
-            function applyFilter() {
-                self.refreshFromOrigialData();
-                Object.keys(self.columnFilters).forEach(function (filter) {
-                    var header = self.getHeaderByName(filter);
-                    if (!header) {
-                        return;
-                    }
-                    self.currentFilter = header.filter || self.filter(header.type || 'string');
-                    self.data = self.data.filter(function (row) {
-                        return self.currentFilter(row[filter], self.columnFilters[filter]);
-                    });
-                });
-                self.resize();
-                self.draw(true);
-            }
             if (column === undefined && value === undefined) {
                 self.columnFilters = {};
             } else if (column && (value === '' || value === undefined)) {
@@ -203,7 +188,7 @@ define([], function () {
             } else {
                 self.columnFilters[column] = value;
             }
-            applyFilter();
+            self.applyFilter();
         };
         /**
          * Returns the number of pixels to scroll down to line up with row rowIndex.

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -198,9 +198,7 @@ define([], function () {
             }
             if (column === undefined && value === undefined) {
                 self.columnFilters = {};
-                return applyFilter();
-            }
-            if (column && (value === '' || value === undefined)) {
+            } else if (column && (value === '' || value === undefined)) {
                 delete self.columnFilters[column];
             } else {
                 self.columnFilters[column] = value;

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -184,7 +184,7 @@ define([], function () {
             function applyFilter() {
                 self.refreshFromOrigialData();
                 Object.keys(self.columnFilters).forEach(function (filter) {
-                    var header = self.getHeaderByName(column);
+                    var header = self.getHeaderByName(filter);
                     if (!header) {
                         return;
                     }

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -188,7 +188,7 @@ define([], function () {
                     if (!header) {
                         return;
                     }
-                    self.currentFilter = header.filter || self.filter(column.type || 'string');
+                    self.currentFilter = header.filter || self.filter(header.type || 'string');
                     self.data = self.data.filter(function (row) {
                         return self.currentFilter(row[filter], self.columnFilters[filter]);
                     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -2322,6 +2322,18 @@
                     grid.data = [{ d: 'gfde' }, { d: 'dcba' }]
                     done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
                 });
+                it('Should retain filters of columns not in new data when data is set', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ d: 'abcd' }, { d: 'edfg' }]
+                    });
+                    grid.setFilter('d', 'a');
+
+                    grid.data = [{ x: 'aaaa' }, { x: 'aaaa' }]
+                    grid.data = [{ d: 'gfde' }, { d: 'dcba' }]
+
+                    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+                });
             });
             describe('Attributes', function () {
                 it('Should store JSON view state data when a name is passed and view state is altered.', function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -2293,6 +2293,15 @@
                     grid.setFilter('d', '/{1}/');
                     done();
                 });
+                it('Should not reset filter when non-existant columns passed to setFilter', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ d: 'abcd' }, { d: 'edfg' }]
+                    });
+                    grid.setFilter('d', 'a');
+                    grid.setFilter('x', 'a');
+                    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+                });
             });
             describe('Attributes', function () {
                 it('Should store JSON view state data when a name is passed and view state is altered.', function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -2244,7 +2244,7 @@
                     });
                     grid.setFilter('d', 'edfg');
                     done(assertIf(grid.data.length === 0 && grid.data[0].d === 'edfg',
-                            'Expected filter to remove all but 1 row.'));
+                        'Expected filter to remove all but 1 row.'));
                 });
                 it('Should remove all filters', function (done) {
                     var grid = g({
@@ -2283,7 +2283,7 @@
                     });
                     grid.setFilter('d', '/\\w/');
                     done(assertIf(grid.data.length === 0 && grid.data[0].d === 'edfg',
-                            'Expected to see a row after a RegExp value.'));
+                        'Expected to see a row after a RegExp value.'));
                 });
                 it('Should tolerate RegExp errors', function (done) {
                     var grid = g({
@@ -2311,6 +2311,15 @@
                     });
                     delete grid.schema[0].filter;
                     grid.setFilter('num', '1');
+                    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+                });
+                it('Should apply filter to new data when data is set', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ d: 'abcd' }, { d: 'edfg' }]
+                    });
+                    grid.setFilter('d', 'a');
+                    grid.data = [{ d: 'gfde' }, { d: 'dcba' }]
                     done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
                 });
             });

--- a/test/tests.js
+++ b/test/tests.js
@@ -2302,6 +2302,17 @@
                     grid.setFilter('x', 'a');
                     done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
                 });
+                it('Should apply correct type filtering method when column filter not set', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ num: 1234 }, { num: 1 }],
+                        schema: [{ name: 'num', type: 'int' }],
+                        filters: { int: function (value, filterFor) { return !filterFor || value.toString() === filterFor; }}
+                    });
+                    delete grid.schema[0].filter;
+                    grid.setFilter('num', '1');
+                    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+                });
             });
             describe('Attributes', function () {
                 it('Should store JSON view state data when a name is passed and view state is altered.', function (done) {


### PR DESCRIPTION
Fixes issue #215.

Changes proposed in this pull request:
- when data is set via the data setter, this applies the currently set filters to the new data set.
- setFilter keeps current filter even when changing the filter value to a non-existent column
- setFilter applies the proper type filter to a column when the schema filter function is not set
