### PR TITLE
retain sort state after changing data

### DIFF
--- a/lib/intf.js
+++ b/lib/intf.js
@@ -209,6 +209,10 @@ define([], function () {
             self.resize();
             self.draw(true);
         };
+        self.applyDataTransforms = function () {
+            self.applyFilter();
+            self.orderings.sort();
+        }
         self.getBestGuessDataType = function (columnName, data) {
             var t, x, l = data.length;
             for (x = 0; x < l; x += 1) {
@@ -1101,9 +1105,8 @@ define([], function () {
                 }
                 // set the unfiltered/sorted data array
                 self.originalData = data;
-                // apply filter to incoming dataset
-                self.applyFilter();
-                self.orderings.sort();
+                // apply filter, sort, etc to incoming dataset
+                self.applyDataTransforms();
                 // empty data was set
                 if (!self.schema && (self.data || []).length === 0) {
                     self.tempSchema = [{name: ''}];

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -24,6 +24,24 @@ define([], function () {
         self.dataType = 'application/x-canvas-datagrid';
         self.orderBy = null;
         self.orderDirection = 'asc';
+        self.orderings = {
+            columns: [],
+            add: function (orderBy, orderDirection, sortFunction) {
+                self.orderings.columns = self.orderings.columns.filter(function (col) {
+                    return col.orderBy !== orderBy;
+                });
+                self.orderings.columns.push({
+                    orderBy: orderBy,
+                    orderDirection: orderDirection,
+                    sortFunction: sortFunction
+                });
+            },
+            sort: function () {
+                self.orderings.columns.forEach(function (col) {
+                    self.data.sort(col.sortFunction(col.orderBy, col.orderDirection));
+                });
+            }
+        };
         self.columnFilters = {};
         self.filters = {};
         self.frozenRow = 0;
@@ -1085,6 +1103,7 @@ define([], function () {
                 self.originalData = data;
                 // apply filter to incoming dataset
                 self.applyFilter();
+                self.orderings.sort();
                 // empty data was set
                 if (!self.schema && (self.data || []).length === 0) {
                     self.tempSchema = [{name: ''}];

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -641,6 +641,7 @@ define([], function () {
                 });
             if (self.dispatchEvent('beforesortcolumn', {name: columnName, direction: direction})) { return; }
             self.orderBy = columnName;
+            self.orderDirection = direction;
             if (!self.data || self.data.length === 0) { return; }
             if (c.length === 0) {
                 throw new Error('Cannot sort.  No such column name');

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -629,7 +629,6 @@ define([], function () {
          * @memberof canvasDatagrid
          * @name order
          * @method
-         * @returns {cell} cell at the selected location.
          * @param {number} columnName Name of the column to be sorted.
          * @param {string} direction `asc` for ascending or `desc` for descending.
          * @param {function} [sortFunction] When defined, override the default sorting method defined in the column's schema and use this one.

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -650,7 +650,8 @@ define([], function () {
             if (!f && c[0].type !== undefined) {
                 console.warn('Cannot sort type "%s" falling back to string sort.', c[0].type);
             }
-            self.data = self.data.sort((typeof f === 'function' ? f : self.sorters.string)(columnName, direction));
+            self.orderings.add(columnName, direction, (typeof f === 'function' ? f : self.sorters.string));
+            self.orderings.sort();
             self.dispatchEvent('sortcolumn', {name: columnName, direction: direction});
             self.draw(true);
             if (dontSetStorageData) { return; }

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -649,7 +649,7 @@ define([], function () {
             if (!f && c[0].type !== undefined) {
                 console.warn('Cannot sort type "%s" falling back to string sort.', c[0].type);
             }
-            self.data = self.data.sort(typeof f === 'function' ? f(columnName, direction) : self.sorters.string);
+            self.data = self.data.sort((typeof f === 'function' ? f : self.sorters.string)(columnName, direction));
             self.dispatchEvent('sortcolumn', {name: columnName, direction: direction});
             self.draw(true);
             if (dontSetStorageData) { return; }

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -188,7 +188,7 @@ define([], function () {
             } else {
                 self.columnFilters[column] = value;
             }
-            self.applyFilter();
+            self.applyDataTransforms();
         };
         /**
          * Returns the number of pixels to scroll down to line up with row rowIndex.

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -645,7 +645,7 @@ define([], function () {
             if (c.length === 0) {
                 throw new Error('Cannot sort.  No such column name');
             }
-            f = sortFunction || self.sorters[c[0].type];
+            f = sortFunction || c[0].sorter || self.sorters[c[0].type];
             if (!f && c[0].type !== undefined) {
                 console.warn('Cannot sort type "%s" falling back to string sort.', c[0].type);
             }

--- a/test/tests.js
+++ b/test/tests.js
@@ -1931,6 +1931,30 @@
                     grid.order('a', 'desc');
                     done(assertIf(grid.data[0].a !== 1503307136397, 'expected to see sort by date desc'));
                 });
+                it('Should set orderBy', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    if (grid.orderBy !== null) {
+                        throw new Error('expected orderBy to be null initially')
+                    }
+                    grid.order('a', 'desc');
+                    done(assertIf(grid.orderBy !== 'a', 'expected orderBy to be set'));
+                });
+                it('Should set orderDirection', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    if (grid.orderDirection !== 'asc') {
+                        throw new Error('expected orderBy to be asc initially')
+                    }
+                    grid.order('a', 'desc');
+                    done(assertIf(grid.orderDirection !== 'desc', 'expected orderDirection to be set'));
+                });
                 it('Should sort with string sorter if type sorter undefined', function (done) {
                     var grid = g({
                         test: this.test,

--- a/test/tests.js
+++ b/test/tests.js
@@ -2080,6 +2080,16 @@
                     grid.data = [{ a: 'a', b: 'a' }, { a: 'b', b: 'a' }, { a: 'c', b: 'b' }];
                     done(assertIf(grid.data[0].a !== 'b', 'expected to see sort by a desc then b asc'));
                 });
+                it('Should reapply current sort after filter', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a', b: 'a' }, { a: 'b', b: 'a' }, { a: 'c', b: 'b' }],
+                        schema: [{ name: 'a', type: 'string' }, { name: 'b', type: 'string' }]
+                    });
+                    grid.order('a', 'desc');
+                    grid.setFilter('b', 'a');
+                    done(assertIf(grid.data[0].a !== 'b', 'expected to see sort by a desc then b asc'));
+                });
             });
             describe('Selections', function () {
                 it('Should select all', function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1931,6 +1931,81 @@
                     grid.order('a', 'desc');
                     done(assertIf(grid.data[0].a !== 1503307136397, 'expected to see sort by date desc'));
                 });
+                it('Should throw when a nonexistant column name is passed', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    var err;
+                    try {
+                        grid.order('x', 'desc');
+                    } catch (e) {
+                        err = e
+                    }
+                    done(assertIf(typeof err === 'undefined', 'Error not thrown'));
+                });
+                it('Should raise beforesortcolumn before sort', function (done) {
+                    var err = new Error('Expected beforesortcolumn event to be raised');
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    grid.addEventListener('beforesortcolumn', function (e) {
+                        err = assertIf(e.name !== 'a', 'name should be "a" but was "%s"', e.column) ||
+                              assertIf(e.direction !== 'desc', 'direction should be "desc" but was "%s"', e.direction) ||
+                              assertIf(grid.data[0].a !== 'a', 'expected data to not be sorted in event');
+                    });
+                    grid.order('a', 'desc');
+                    done(err || assertIf(grid.data[0].a !== 'c', 'expected data to be sorted'));
+                });
+                it('Should not sort when beforesortcolumn prevents default', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    grid.addEventListener('beforesortcolumn', function (e) { e.preventDefault(); });
+                    grid.order('a', 'desc');
+                    done(assertIf(grid.data[0].a !== 'a', 'expected no change in sort order'));
+                });
+                it('Should raise sortcolumn event after sort', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    grid.addEventListener('sortcolumn', function (e) {
+                        done(assertIf(e.name !== 'a', 'name should be "a" but was "%s"', e.column) ||
+                             assertIf(e.direction !== 'desc', 'direction should be "desc" but was "%s"', e.direction) ||
+                             assertIf(grid.data[0].a !== 'c', 'expected data to be sorted'));
+                    });
+                    grid.order('a', 'desc');
+                });
+                it('Should raise sortcolumn event only once', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    var callCnt = 0;
+                    grid.addEventListener('sortcolumn', function (e) { callCnt++; });
+                    grid.order('a', 'desc');
+
+                    done(assertIf(callCnt !== 1, 'expected sort column to only be called once'));
+                });
+                it('Should not raise sortcolumn event when beforesortcolumn prevents default', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a' }, { a: 'b' }, { a: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }]
+                    });
+                    grid.addEventListener('beforesortcolumn', function (e) { e.preventDefault(); });
+                    grid.addEventListener('sortcolumn', function (e) { throw new Error("sortcolumn event"); });
+                    grid.order('a', 'desc');
+                    done();
+                });
             });
             describe('Selections', function () {
                 it('Should select all', function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -2026,6 +2026,25 @@
                     grid.order('a', 'desc');
                     done();
                 });
+                it('Should apply the schema sorter to sort data', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'ab' }, { a: 'ba' }, { a: 'cd' }, { a: 'dc' }],
+                        schema: [{
+                            name: 'a',
+                            type: 'string',
+                            sorter: function (col, dir) {
+                                var mult = (dir === "desc" ? -1 : 1);
+                                return function (x, y) {
+                                    var x1 = x[col].charCodeAt(1), y1 = y[col].charCodeAt(1);
+                                    return mult * (x1 - y1);
+                                }
+                            }
+                        }]
+                    });
+                    grid.order('a', 'desc');
+                    done(assertIf(grid.data[0].a !== 'cd', 'expected schema sorter to be used'));
+                });
             });
             describe('Selections', function () {
                 it('Should select all', function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -2069,6 +2069,17 @@
                     grid.order('a', 'desc');
                     done(assertIf(grid.data[0].a !== 'cd', 'expected schema sorter to be used'));
                 });
+                it('Should reapply current sort after data set', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a', b: 'a' }, { a: 'b', b: 'b' }, { a: 'c', b: 'c' }],
+                        schema: [{ name: 'a', type: 'string' }, { name: 'b', type: 'string' }]
+                    });
+                    grid.order('a', 'desc');
+                    grid.order('b', 'asc');
+                    grid.data = [{ a: 'a', b: 'a' }, { a: 'b', b: 'a' }, { a: 'c', b: 'b' }];
+                    done(assertIf(grid.data[0].a !== 'b', 'expected to see sort by a desc then b asc'));
+                });
             });
             describe('Selections', function () {
                 it('Should select all', function (done) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1931,6 +1931,16 @@
                     grid.order('a', 'desc');
                     done(assertIf(grid.data[0].a !== 1503307136397, 'expected to see sort by date desc'));
                 });
+                it('Should sort with string sorter if type sorter undefined', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: '0' }, { a: '10' }, { a: '2' }],
+                        schema: [{ name: 'a', type: 'xxx' }],
+                        formatters: { xxx: function (e) { return e.cell.value.toString(); }}
+                    });
+                    grid.order('a', 'desc');
+                    done(assertIf(grid.data[0].a !== '2', 'expected to see sort by string desc'));
+                });
                 it('Should throw when a nonexistant column name is passed', function (done) {
                     var grid = g({
                         test: this.test,

--- a/test/tests.js
+++ b/test/tests.js
@@ -1941,6 +1941,16 @@
                     grid.order('a', 'desc');
                     done(assertIf(grid.data[0].a !== '2', 'expected to see sort by string desc'));
                 });
+                it('Should preserve current sort order, effectively allowing sort on multiple columns', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ a: 'a', b: 'a' }, { a: 'b', b: 'a' }, { a: 'c', b: 'b' }],
+                        schema: [{ name: 'a', type: 'string' }, { name: 'b', type: 'string' }]
+                    });
+                    grid.order('a', 'desc');
+                    grid.order('b', 'asc');
+                    done(assertIf(grid.data[0].a !== 'b', 'expected to see sort by a desc then b asc'));
+                });
                 it('Should throw when a nonexistant column name is passed', function (done) {
                     var grid = g({
                         test: this.test,


### PR DESCRIPTION
Fixes issue #217.

Changes proposed in this pull request:

- added tests around current order behavior
- fixes order when sortFunction defaults to string sorter
- fixes order to use sorter on schema if defined
- resorts after setting data
- resorts after filtering data
