### PR TITLE
dispatch event copyonschema to set column schema for copying

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1257,6 +1257,11 @@ define([], function () {
                     // intentional redefinition of column
                     column = s[self.orders.columns[columnIndex]];
                     if (!column.hidden && headers.indexOf(column.name) !== -1) {
+                        var ev = {NativeEvent: e, column: column};
+                        if(self.dispatchEvent('copyonschema', ev)) {
+                            column = ev.column;
+                        }
+
                         var hVal = (column.name || column.title) || '';
                         if (useHtml) {
                             h.push('<th>' + htmlSafe(hVal) + '</th>');


### PR DESCRIPTION
Fixes issue #216.

Changes proposed in this pull request:

- add event *copyonschema* to set column schema for copying

custom the column.name to be copied:

```
grid.addEventListener('copyonschema', function(evt){
    evt.column.name = 'Column Name';
});

```

or null the column.name to let column.title be copied:

```
grid.addEventListener('copyonschema', function(evt){
    evt.column.name = null;
});

```

