### PR TITLE
dispatch event copyonschema to set column schema for copying

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -511,6 +511,17 @@
  * @param {object} e.NativeEvent Native copy event.
 */
 /**
+ * Fires when a copy is processing on a schema column. If you want to change headers of the copied data, this is the event to attach to.
+ * Changing `column.title` or `column.name` will not change actual schema, it will just take effect and apply to the copied data.
+ * @event
+ * @name canvasDatagrid#copyonschema
+ * @param {object} e Event object
+ * @param {object} e.ctx Canvas context.
+ * @param {function} e.preventDefault Prevents the default behavior.
+ * @param {object} e.NativeEvent Native copy event.
+ * @param {object} e.column Current column object of schema.
+*/
+/**
  * Fired just before a cell is drawn onto the canvas.  `e.preventDefault();` prevents the cell from being drawn.
  * You would only use this if you want to completely stop the cell from being drawn and generally muck up everything.
  * @event

--- a/lib/events.js
+++ b/lib/events.js
@@ -1257,6 +1257,11 @@ define([], function () {
                     // intentional redefinition of column
                     column = s[self.orders.columns[columnIndex]];
                     if (!column.hidden && headers.indexOf(column.name) !== -1) {
+                        var ev = {NativeEvent: e, column: column};
+                        if(self.dispatchEvent('copyonschema', ev)) {
+                            column = ev.column;
+                        }
+
                         var hVal = (column.name || column.title) || '';
                         if (useHtml) {
                             h.push('<th>' + htmlSafe(hVal) + '</th>');


### PR DESCRIPTION
Fixes issue #216.

Changes proposed in this pull request:

- add event *copyonschema* to set column schema for copying

custom the column.name to be copied:

```
grid.addEventListener('copyonschema', function(evt){
    evt.column.name = 'Column Name';
});

```

or null the column.name to let column.title be copied:

```
grid.addEventListener('copyonschema', function(evt){
    evt.column.name = null;
});

```

