### PR TITLE
Fix a bug: grid.data accidentally set to innerHTML

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -175,7 +175,7 @@ define(['./defaults'], function (defaults) {
                         checkStyle = true;
                         return;
                     }
-                    if (mutation.target === intf && mutation.addedNodes.length > 0 || mutation.type === 'characterData') {
+                    if (mutation.target === intf && (mutation.addedNodes.length > 0 || mutation.type === 'characterData')) {
                         checkInnerHTML = true;
                     }
                 });

--- a/lib/component.js
+++ b/lib/component.js
@@ -175,7 +175,7 @@ define(['./defaults'], function (defaults) {
                         checkStyle = true;
                         return;
                     }
-                    if (mutation.addedNodes.length > 0 || mutation.type === 'characterData') {
+                    if (mutation.target === intf && mutation.addedNodes.length > 0 || mutation.type === 'characterData') {
                         checkInnerHTML = true;
                     }
                 });

--- a/lib/component.js
+++ b/lib/component.js
@@ -170,6 +170,10 @@ define(['./defaults'], function (defaults) {
                         checkStyle = true;
                         return;
                     }
+                    if (mutation.target.nodeName === 'STYLE') {
+                        checkStyle = true;
+                        return;
+                    }
                     if (mutation.target.parentNode
                             && mutation.target.parentNode.nodeName === 'STYLE') {
                         checkStyle = true;


### PR DESCRIPTION
If some style element added a text node. It will cause canvas-datagrid use interHTML to overwrite it's data.

Fixes issue #.

Changes proposed in this pull request:

- 
- 
- 
