### PR TITLE
#251 Remove deprecated createShadowRoot

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -518,9 +518,7 @@ define([], function () {
                     self.canvas = self.parentDOMNode;
                 } else {
                     self.canvas = document.createElement('canvas');
-                    if (self.intf.createShadowRoot) {
-                        self.parentDOMNode.appendChild(self.canvas);
-                    }
+                    self.parentDOMNode.appendChild(self.canvas);
                 }
                 document.body.appendChild(self.controlInput);
                 self.createInlineStyle(self.canvas, 'canvas-datagrid');

--- a/lib/main.js
+++ b/lib/main.js
@@ -40,11 +40,9 @@ define([
         if (self.isChildGrid) {
             self.shadowRoot = args.parentNode.shadowRoot;
             self.parentNode = args.parentNode;
-        } else if (self.intf.createShadowRoot) {
+        } else {
             self.shadowRoot = self.intf.attachShadow({mode: 'open'});
             self.parentNode = self.shadowRoot;
-        } else {
-            self.parentNode = self.intf;
         }
         self.init();
         return self.intf;
@@ -70,7 +68,7 @@ define([
         args = args || {};
         var i, tKeys = ['style', 'formatters', 'sorters', 'filters',
                     'treeGridAttributes', 'cellGridAttributes', 'data', 'schema'];
-        if (window.customElements && document.body.createShadowRoot) {
+        if (window.customElements) {
             i = document.createElement('canvas-datagrid');
             Object.keys(args).forEach(function (argKey) {
                 // set data and parentNode after everything else


### PR DESCRIPTION
Fixes issue #251 .

https://developer.mozilla.org/en-US/docs/Web/API/Element/createShadowRoot
createShadowRoot is deprecated in Chrome 80. Hence removing the usages.
