### PR TITLE
Fixing columnIndex key missing from schema column

### DIFF
--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -1005,6 +1005,7 @@ define([], function () {
                         name: key,
                         title: isNaN(parseInt(key, 10)) ? key : self.integerToAlpha(key).toUpperCase(),
                         index: index,
+                        columnIndex: index,
                         type: type,
                         filter: self.filter(type)
                     };


### PR DESCRIPTION
Copy/Paste doesn't work if just providing data and no schema. If the schema is auto generated, each column is missing columnIndex which is referenced when pasting content.

Fixes issue #269

Changes proposed in this pull request:

- Adding columnIndex to auto generated schema column
