### PR TITLE
Add singleSelectionMode setting

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -68,6 +68,7 @@ define([], function () {
                 ['showPerformance', false],
                 ['showRowHeaders', true],
                 ['showRowNumbers', true],
+                ['singleSelectionMode', false],
                 ['snapToRow', false],
                 ['touchContextMenuTimeMs', 800],
                 ['touchDeadZone', 3],

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -34,7 +34,8 @@
  * @param {boolean} [args.allowSorting=true] - Allow user to sort rows by clicking on column headers.
  * @param {boolean} [args.showFilter=true] - When true, filter will be an option in the context menu.
  * @param {number} [args.pageUpDownOverlap=1] - Amount of rows to overlap when pageup/pagedown is used.
- * @param {boolean} [args.persistantSelectionMode=false] - When true, selections will behave as if the command/control key is held down at all times.
+ * @param {boolean} [args.persistantSelectionMode=false] - When true, selections will behave as if the command/control key is held down at all times. Conflicts with singleSelectionMode.
+ * @param {boolean} [args.singleSelectionMode=false] - When true, selections will ignore the command/control key. Conflicts with persistantSelectionMode.
  * @param {string} [args.selectionMode='cell'] - Can be 'cell', or 'row'.  This setting dictates what will be selected when the user clicks a cell.  The cell, or the entire row respectively.
  * @param {boolean} [args.autoResizeColumns=false] - When true, all columns will be automatically resized to fit the data in them. Warning! Expensive for large (&gt;100k ~2 seconds) datasets.
  * @param {boolean} [args.allowRowHeaderResize=true] - When true, the user can resize the width of the row headers.

--- a/lib/events.js
+++ b/lib/events.js
@@ -345,7 +345,7 @@ define([], function () {
                 return;
             }
             self.mouse = overridePos || self.getLayerPos(e);
-            var ctrl = (e.ctrlKey || e.metaKey || self.attributes.persistantSelectionMode),
+            var ctrl = ((e.ctrlKey || e.metaKey || self.attributes.persistantSelectionMode) && !self.attributes.singleSelectionMode),
                 i,
                 s = self.getSchema(),
                 dragBounds,
@@ -462,7 +462,7 @@ define([], function () {
         self.click = function (e, overridePos) {
             var i,
                 startingBounds = JSON.stringify(self.getSelectionBounds()),
-                ctrl = (e.ctrlKey || e.metaKey || self.attributes.persistantSelectionMode),
+                ctrl = ((e.ctrlKey || e.metaKey || self.attributes.persistantSelectionMode) && !self.attributes.singleSelectionMode),
                 pos = overridePos || self.getLayerPos(e);
             self.currentCell = self.getCellAt(pos.x, pos.y);
             if (self.currentCell.grid !== undefined) {


### PR DESCRIPTION
Fixes issue #273.

Changes proposed in this pull request:

Add a "singleSelectionMode" option which causes the control/meta keys to be ignored.
This obviously conflicts with "persistantSelectionMode", currently singleSelectionMode overrides persistantSelectionMode.
