### PR TITLE
isCellVisible documentation issue

### DIFF
--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -601,14 +601,6 @@ define([], function () {
          * @param {number} columnIndex The column index of the cell to check.
          * @param {number} rowIndex The row index of the cell to check.
          */
-        /**
-         * Checks if a cell is currently visible.
-         * @memberof canvasDatagrid
-         * @name isCellVisible
-         * @method
-         * @returns {boolean} when true, the cell is visible, when false the cell is not currently drawn.
-         * @param {cell} cell The cell to check for.  Alternatively you can pass an object { x: <x-pixel-value>, y: <y-pixel-value> }.
-         */
         self.isCellVisible = function (cell, rowIndex) {
             // overload
             if (rowIndex !== undefined) {


### PR DESCRIPTION
Fixes issue #110.

Changes proposed in this pull request:

Removal of repeated function description in `publicMethods.js` to prevent duplication of isCellVisible() method documentation.

