### PR TITLE
resolve flickering cells

### DIFF
--- a/lib/draw.js
+++ b/lib/draw.js
@@ -47,7 +47,7 @@ define([], function () {
         function drawOnAllImagesLoaded() {
             var loaded = true;
             Object.keys(self.htmlImageCache).forEach(function (html) {
-                if (!self.htmlImageCache[html].complete) {
+                if (!self.htmlImageCache[html].img.complete) {
                     loaded = false;
                 }
             });
@@ -63,8 +63,8 @@ define([], function () {
                 x = cell.x + self.canvasOffsetLeft,
                 y = cell.y + self.canvasOffsetTop;
             if (self.htmlImageCache[cacheKey]) {
-                img = self.htmlImageCache[cacheKey];
-                if (img.height !== cell.height || img.width !== cell.width) {
+                img = self.htmlImageCache[cacheKey].img;
+                if (self.htmlImageCache[cacheKey].height !== cell.height || self.htmlImageCache[cacheKey].width !== cell.width) {
                     // height and width of the cell has changed, invalidate cache
                     self.htmlImageCache[cacheKey] = undefined;
                 } else {
@@ -77,7 +77,7 @@ define([], function () {
                 cachedImagesDrawn = false;
             }
             img = new Image(cell.width, cell.height);
-            self.htmlImageCache[cacheKey] = img;
+            self.htmlImageCache[cacheKey] = { img, width: cell.width, height: cell.height };
             img.onload = function () {
                 self.ctx.drawImage(img, x, y);
                 drawOnAllImagesLoaded();


### PR DESCRIPTION
Flickering cells when use HTML rendering (schema data type is 'html' or set cell's innerHTML attribute in 'afterrendercell' event handler)

set grid `autoResizeColumns = true` (because value of cell width is float. Cell also flickering when set float value of column width `grid.setColumnWidth(i, 10.1)` )

see example (from 'Draw HTML via data type’ doc tutorials): https://jsfiddle.net/BlackTea1105/9kmu62jL/1/


the drawHtml function in the libs/draw.js, if cell’s size (width / height) not equals cell cache size (htmlImageCache), will clear cache and regenerate Image Element.

But the HTMLImageElement size (width and height) type always is integer, so if cell’s width is float, its never equals its cache’s width.

So I add more information into htmlImageCache (cell’s size).