### PR TITLE
Manually set `grid.style.height` reset to 'auto' when applyComponentS…

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -146,8 +146,8 @@ define([], function () {
                     if (['auto', undefined].indexOf(self.style[dim]) !== -1
                             && ['auto', undefined].indexOf(self.appliedInlineStyles[dim]) !== -1) {
                         self.parentNodeStyle[dim] = dims[dim] + 'px';
-                    } else {
-                        self.parentNodeStyle[dim] = self.style[dim];
+                    } else if (['auto', undefined].indexOf(self.style[dim]) == -1
+                            && ['auto', undefined].indexOf(self.appliedInlineStyles[dim]) == -1) {                        self.parentNodeStyle[dim] = self.style[dim];
                         if (self.isComponet) {
                             self.canvas.style[dim] = self.style[dim];
                         }

--- a/lib/events.js
+++ b/lib/events.js
@@ -147,7 +147,8 @@ define([], function () {
                             && ['auto', undefined].indexOf(self.appliedInlineStyles[dim]) !== -1) {
                         self.parentNodeStyle[dim] = dims[dim] + 'px';
                     } else if (['auto', undefined].indexOf(self.style[dim]) == -1
-                            && ['auto', undefined].indexOf(self.appliedInlineStyles[dim]) == -1) {                        self.parentNodeStyle[dim] = self.style[dim];
+                            && ['auto', undefined].indexOf(self.appliedInlineStyles[dim]) == -1) {
+                        self.parentNodeStyle[dim] = self.style[dim];
                         if (self.isComponet) {
                             self.canvas.style[dim] = self.style[dim];
                         }


### PR DESCRIPTION
…tyle() is called

Fixes issue #282 

When the 'canvas-datagrid' is used with 'golden-layout', there is a problem with the display style. When dragging the subpage window, the 'canvas-datagrid' will crash.


- demo [mmk.zip](https://github.com/TonyGermaneri/canvas-datagrid/files/4987052/mmk.zip)

```html
<script src="https://tonygermaneri.github.io/canvas-datagrid/dist/canvas-datagrid.debug.js"></script>
<!-- <script src="./canvas-datagrid.debug-fixed.js"></script> -->
```

- Switch comments to see the modification effect.


