### PR TITLE
Fixes scrolling behaviour in safari.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1104,13 +1104,14 @@ define([], function () {
                 deltaX = e.deltaX === undefined ? e.NativeEvent.deltaX : e.deltaX,
                 deltaY = e.deltaY === undefined ? e.NativeEvent.deltaY : e.deltaY,
                 deltaMode = e.deltaMode === undefined ? e.NativeEvent.deltaMode : e.deltaMode;
+            var e = e.NativeEvent || e;
             if (wheeling) {
+                ev.preventDefault(e);
                 return;
             }
             if (self.dispatchEvent('wheel', {NativeEvent: e})) {
                 return;
             }
-            var e = e.NativeEvent || e;
             self.touchHaltAnimation = true;
             l = self.scrollBox.scrollLeft;
             t = self.scrollBox.scrollTop;


### PR DESCRIPTION
Where scrolling and moving your mouse at the same time actually also scrolled the page for a bit.

Fixes issue #285.

Changes proposed in this pull request:

- Fix scrolling behaviour in safari (for trackpad and/or magic mouse)

I'll remove the test file if you are willing to take this pull request, but it's there at the moment because it's super easy to test.
