### PR TITLE
column width calculation error when using custom "formatter"

### DIFF
--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -1077,6 +1077,7 @@ define([], function () {
                     + (self.attributes.tree ? self.style.treeArrowWidth
                         + self.style.treeArrowMarginLeft + self.style.treeArrowMarginRight : 0);
             }
+            var formatter = null;
             self.getSchema().forEach(function (col) {
                 if (col.name !== name) { return; }
                 self.ctx.font = self.style.columnHeaderCellFont;
@@ -1084,10 +1085,15 @@ define([], function () {
                     + self.style.headerCellPaddingRight
                     + self.style.headerCellPaddingLeft;
                 m = t > m ? t : m;
+                formatter = self.formatters[col.type];
             });
             self.data.forEach(function (row) {
+                var text = row[name];
+                if (formatter) {
+                    text = formatter({cell:{value:text}});
+                }
                 self.ctx.font = self.style.cellFont;
-                var t = self.ctx.measureText(row[name]).width
+                var t = self.ctx.measureText(text).width
                     + self.style.cellPaddingRight
                     + self.style.cellPaddingLeft + self.style.cellAutoResizePadding;
                 m = t > m ? t : m;


### PR DESCRIPTION
When using a custom formatter method, if the length of the string returned by the custom formatter method is longer than the original string length, the displayed text will be truncated.

This modification solves the problem of text being truncated by using the return value of the formatter method to calculate the width of the string.