### PR TITLE
Paste event improvements

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -523,6 +523,23 @@
  * @param {object} e.column Current column object of schema.
 */
 /**
+ * Fires before a paste is performed. 
+ * @event
+ * @name canvasDatagrid#beforepaste
+ * @param {object} e Event object
+ * @param {object} e.ctx Canvas context.
+ * @param {function} e.preventDefault Prevents the default behavior.
+ * @param {object} e.NativeEvent Native paste event.
+*/
+/**
+ * Fires after a paste is performed.
+ * @event
+ * @name canvasDatagrid#afterpaste
+ * @param {object} e Event object
+ * @param {object} e.ctx Canvas context.
+ * @param {array} e.cells Cells affected by the paste action. Each item in the array is a tuple of [rowIndex, columnIndex].
+*/
+/**
  * Fired just before a cell is drawn onto the canvas.  `e.preventDefault();` prevents the cell from being drawn.
  * You would only use this if you want to completely stop the cell from being drawn and generally muck up everything.
  * @event

--- a/lib/events.js
+++ b/lib/events.js
@@ -33,7 +33,7 @@ define([], function () {
             });
         };
         /**
-         * Fires the given event, padding an event object to the event subscribers.
+         * Fires the given event, passing an event object to the event subscribers.
          * @memberof canvasDatagrid
          * @name dispatchEvent
          * @method
@@ -1209,6 +1209,21 @@ define([], function () {
 
             self.selections = selections;
 
+            // selections is a sparse array, so we condense:
+            var affectedCells = [];
+
+            selections.forEach(function (row, rowIndex) {
+                if (rowIndex === undefined) return;
+
+                row.forEach(function (columnIndex) {
+                    affectedCells.push([rowIndex, columnIndex]);
+                });
+            });
+
+            self.dispatchEvent('afterpaste', {
+                cells: affectedCells,
+            });
+
             return rows.length;
         }
         self.getNextVisibleColumnIndex = function (visibleColumnIndex) {
@@ -1230,6 +1245,12 @@ define([], function () {
             return -1;
         };
         self.paste = function (event) {
+            var defaultPrevented = self.dispatchEvent('beforepaste', { NativeEvent: event });
+
+            if (defaultPrevented) {
+                return;
+            }
+
             var clipboardItems = new Map(
                 Array.from(event.clipboardData.items).map(item => [item.type, item])
             );

--- a/lib/events.js
+++ b/lib/events.js
@@ -1133,56 +1133,84 @@ define([], function () {
                 }, 1);
             }
         };
-        self.pasteItem = function (clipData, x, y, mimeType) {
-            var l, s = self.getVisibleSchema(), yi = y - 1, sel = [];
-            function normalizeRowData(importingRow, existingRow, offsetX, schema, mimeType, rowIndex) {
-                var r = existingRow;
-                if (!Array.isArray(importingRow) && importingRow !== null && typeof importingRow === 'object') {
-                    importingRow = Object.keys(importingRow).map(function (colKey) {
-                        return importingRow[colKey];
-                    });
+
+        self.pasteData = function(pasteValue, mimeType, startRowIndex, startColIndex) {
+            var schema = self.getVisibleSchema();
+
+            const isSupportedHtmlTable = htmlString => /^(<meta[^>]+>)?<table>/.test(htmlString.substring(0, 29));
+
+            // TODO: support pasting tables from Excel 
+            if (mimeType === "text/html" && isSupportedHtmlTable(pasteValue) === false) {
+                console.warn('Unrecognized HTML format. HTML must be a simple table, e.g.: <table><tr><td>data</td></tr></table>.');
+                console.warn('Data with the mime type text/html not in this format will not be imported as row data.');
+
+                return;
+            }
+
+            function parseData(data, mimeType) {
+                // TODO: use DOMParser
+                if (mimeType === "text/html") {
+                    // strip table beginning and ending off, then split at rows
+                    var cleanedHtmlData = data.substring(
+                        data.indexOf('<table><tr>') + 11, data.length - 13
+                    ).split('</tr><tr>').filter(
+                        // ditch any headers on the table
+                        row => !/^<th>|^<thead>/.test(row)
+                    ).map(
+                        // split row into individual cells
+                        row => row.match(/<td>[^<]+/g).map(match => match.replace(/^<td>/, '')
+                    ));
+
+                    return cleanedHtmlData;
                 }
-                if (/^text\/html/.test(mimeType)) {
-                    importingRow = importingRow.substring(4, importingRow.length - 5).split('</td><td>');
-                }
-                if (typeof importingRow === 'string') {
-                    importingRow = [importingRow];
-                }
-                sel[rowIndex] = [];
-                importingRow.forEach(function (cellData, colIndex) {
-                    var cName = schema[colIndex + offsetX].name;
-                    if (importingRow[colIndex] === undefined || importingRow[colIndex] === null) {
-                        r[cName] = existingRow[cName];
-                        return;
+
+                // Default data format is string, so split on new line,
+                // and then enclose in an array (a row with one cell):
+                return data.split("\n").map(value => [value]);
+            }
+
+            var rows = parseData(pasteValue, mimeType);
+            var selections = [];
+
+            for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+                // Rows may have been moved by user, so get the actual row index
+                // (instead of the row index at which the row is rendered):
+                var realRowIndex = self.orders.rows[startRowIndex + rowIndex];
+                var cells = rows[rowIndex];
+
+                var existingRowData = self.data[realRowIndex];
+                var newRowData = Object.assign({}, existingRowData);
+
+                selections[realRowIndex] = [];
+
+                for (var colIndex = 0; colIndex < cells.length; colIndex++) {
+                    var column = schema[startColIndex + colIndex];
+
+                    if (!column) {
+                        console.warn("Paste data exceeded grid bounds. Skipping.");
+                        continue;
                     }
-                    sel[rowIndex].push(colIndex + offsetX);
-                    r[cName] = importingRow[colIndex];
-                });
-                return r;
-            }
-            if (/^text\/html/.test(mimeType)) {
-                if (!/^(<meta[^>]+>)?<table>/.test(clipData.substring(0, 29))) {
-                    console.warn('Unrecognized HTML format.  HTML must be a simple table, e.g.: <table><tr><td>data</td></tr></table>.  Data with the mime type text/html not in this format will not be imported as row data.');
-                    return;
+    
+                    var columnName = column.name;
+                    var cellData = cells[colIndex];
+
+                    if (cellData === undefined || cellData === null) {
+                        newRowData[columnName] = existingRowData[columnName];
+                        continue;
+                    }
+
+                    selections[realRowIndex].push(startColIndex + colIndex);
+
+                    newRowData[columnName] = cellData;
                 }
-                // strip table beginning and ending off, then split at rows
-                clipData = clipData.substring(clipData.indexOf('<table><tr>') + 11, clipData.length - 13).split('</tr><tr>');
-                // ditch any headers on the table
-                clipData = clipData.filter(function (row) {
-                    return !/^<th>|^<thead>/.test(row);
-                });
-            } else {
-                clipData = clipData.split('\n');
+
+                self.data[realRowIndex] = newRowData;
             }
-            l = clipData.length;
-            clipData.forEach(function (rowData) {
-                yi += 1;
-                var i = self.orders.rows[yi];
-                self.data[i] = normalizeRowData(rowData, self.data[i], x, s, mimeType, i);
-            });
-            self.selections = sel;
-            return l;
-        };
+
+            self.selections = selections;
+
+            return rows.length;
+        }
         self.getNextVisibleColumnIndex = function (visibleColumnIndex) {
             var x, s = self.getVisibleSchema();
             for (x = 0; x < s.length; x += 1) {
@@ -1229,11 +1257,11 @@ define([], function () {
             var pasteType = itemToPaste.type;
 
             itemToPaste.getAsString(function (pasteValue) {
-                self.pasteItem(
+                self.pasteData(
                     pasteValue,
-                    self.getVisibleColumnIndexOf(self.activeCell.columnIndex),
+                    pasteType,
                     self.activeCell.rowIndex,
-                    pasteType
+                    self.getVisibleColumnIndexOf(self.activeCell.columnIndex),
                 );
 
                 self.draw();

--- a/lib/events.js
+++ b/lib/events.js
@@ -1201,27 +1201,43 @@ define([], function () {
             }
             return -1;
         };
-        self.paste = function (e) {
-            var d;
-            function getItem(dti) {
-                var type = dti.type;
-                dti.getAsString(function (s) {
-                    self.pasteItem(s, self.getVisibleColumnIndexOf(self.activeCell.columnIndex), self.activeCell.rowIndex, type);
-                    self.draw();
-                });
-            }
-            d = Array.prototype.filter.call(e.clipboardData.items, function (dti) {
-                return dti.type === 'text/html';
-            })[0] || Array.prototype.filter(function (dti) {
-                return dti.type === 'text/csv';
-            })[0] || Array.prototype.filter(function (dti) {
-                return dti.type === 'text/plain';
-            })[0];
-            if (!d) {
-                console.warn('Cannot find supported clipboard data type.  Supported types are text/html, text/csv, text/plain.');
+        self.paste = function (event) {
+            var clipboardItems = new Map(
+                Array.from(event.clipboardData.items).map(item => [item.type, item])
+            );
+
+            // Supported MIME types, in order of preference:
+            var supportedMimeTypes = ['text/html', 'text/csv', 'text/plain'];
+
+            // The clipboard will often contain the same data in multiple formats,
+            // which can be used depending on the context in which it's pasted. Here
+            // we'll prefere more structured (HTML/CSV) over less structured, when
+            // available, so we try to find those first:
+            var pasteableItems = supportedMimeTypes.map(
+                mimeType => clipboardItems.get(mimeType)
+            ).filter(item => !!item); // filter out not-found MIME types (= undefined)
+
+            if (pasteableItems.length === 0) {
+                console.warn('Cannot find supported clipboard data type. Supported types are:', supportedMimeTypes.join(', '));
                 return;
             }
-            getItem(d);
+
+            var itemToPaste = pasteableItems[0];
+
+            // itemToPaste is cleared once accessed (getData or getAsString),
+            // so we need to store the type here, before reading its value:
+            var pasteType = itemToPaste.type;
+
+            itemToPaste.getAsString(function (pasteValue) {
+                self.pasteItem(
+                    pasteValue,
+                    self.getVisibleColumnIndexOf(self.activeCell.columnIndex),
+                    self.activeCell.rowIndex,
+                    pasteType
+                );
+
+                self.draw();
+            });
         };
         self.cut = function (e) {
             self.copy(e);

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -537,6 +537,7 @@ define([], function () {
             self.intf.clearPxColorAssertions = self.clearPxColorAssertions;
             self.intf.integerToAlpha = self.integerToAlpha;
             self.intf.copy = self.copy;
+            self.intf.paste = self.paste;
             self.intf.setStyleProperty = self.setStyleProperty;
             Object.defineProperty(self.intf, 'defaults', {
                 get: function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1529,14 +1529,13 @@
                     grid.focus();
                     grid.setActiveCell(0, 0);
 
-                    // grid.paste is not a function?
                     grid.paste({
                         clipboardData: {
                             items: [
                                 {
-                                    type: 'text/html',
-                                    getAsString: function() {
-                                        return 'Paste buffer value';
+                                    type: 'text/plain',
+                                    getAsString: function(callback) {
+                                        callback('Paste buffer value');
                                     }
                                 }
                             ]
@@ -1544,13 +1543,87 @@
                     });
 
                     setTimeout(function() {
-                        done(
-                            assertIf(grid.data[0]["Column A"] === "Paste buffer value", "Value has been replaced with clipboard data")
-                        );
+                        var cellData = grid.data[0]['Column A'];
+                        done(assertIf(cellData !== 'Paste buffer value', 'Value has not been replaced with clipboard data: ' + cellData));
                     }, 10);
                 });
-                it.skip("Should fire a beforepaste event");
-                it.skip("Should fire an afterpaste event");
+                it('Should paste an HTML value from the clipboard into a cell', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            { 'Column A': 'Original value' }
+                        ]
+                    });
+
+                    grid.focus();
+                    grid.setActiveCell(0, 0);
+
+                    grid.paste({
+                        clipboardData: {
+                            items: [
+                                {
+                                    type: 'text/html',
+                                    getAsString: function(callback) {
+                                        callback("<meta charset='utf-8'><table><tr><td>Paste buffer value</td></tr></table>");
+                                    }
+                                }
+                            ]
+                        }
+                    });
+
+                    setTimeout(function() {
+                        var cellData = grid.data[0]['Column A'];
+                        done(assertIf(cellData !== 'Paste buffer value', 'Value has not been replaced with clipboard data: ' + cellData));
+                    }, 10);
+                });
+                it("Should fire a beforepaste event", function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            { 'Column A': 'Original value' }
+                        ]
+                    });
+
+                    grid.focus();
+                    grid.setActiveCell(0, 0);
+
+                    grid.addEventListener('beforepaste', function (event) {
+                        event.preventDefault();
+                        done();
+                    });
+
+                    // Event can be empty, because beforepaste should fire immediately,
+                    // and return from paste function (because preventDefault):
+                    grid.paste({});
+                });
+                it("Should fire an afterpaste event", function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            { 'Column A': 'Original value' }
+                        ]
+                    });
+
+                    grid.focus();
+                    grid.setActiveCell(0, 0);
+
+                    grid.addEventListener('afterpaste', function (event) {
+                        done();
+                    });
+
+                    grid.paste({
+                        clipboardData: {
+                            items: [
+                                {
+                                    type: 'text/plain',
+                                    getAsString: function(callback) {
+                                        callback('Paste buffer value');
+                                    }
+                                }
+                            ]
+                        }
+                    });
+                });
                 it('Begin editing, tab to next cell', function (done) {
                     var ev,
                         err,

--- a/test/tests.js
+++ b/test/tests.js
@@ -1518,6 +1518,39 @@
                         });
                     }, 1);
                 });
+                it('Should paste a value from the clipboard into a cell', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            { 'Column A': 'Original value' }
+                        ]
+                    });
+
+                    grid.focus();
+                    grid.setActiveCell(0, 0);
+
+                    // grid.paste is not a function?
+                    grid.paste({
+                        clipboardData: {
+                            items: [
+                                {
+                                    type: 'text/html',
+                                    getAsString: function() {
+                                        return 'Paste buffer value';
+                                    }
+                                }
+                            ]
+                        }
+                    });
+
+                    setTimeout(function() {
+                        done(
+                            assertIf(grid.data[0]["Column A"] === "Paste buffer value", "Value has been replaced with clipboard data")
+                        );
+                    }, 10);
+                });
+                it.skip("Should fire a beforepaste event");
+                it.skip("Should fire an afterpaste event");
                 it('Begin editing, tab to next cell', function (done) {
                     var ev,
                         err,


### PR DESCRIPTION
Adds `beforepaste` and `afterpaste` events. Includes a rewrite of the `paste` method, more for clarity and adding comments than anything else, but in the process I fixed a bug where attempting to paste beyond the grid boundaries resulted in an error.
