### PR TITLE
Fill paste values in multiple selected cells

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1172,40 +1172,52 @@ define([], function () {
             var rows = parseData(pasteValue, mimeType);
             var selections = [];
 
-            for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) {
-                // Rows may have been moved by user, so get the actual row index
-                // (instead of the row index at which the row is rendered):
-                var realRowIndex = self.orders.rows[startRowIndex + rowIndex];
-                var cells = rows[rowIndex];
+            // Special case: if rows.length = 1, we paste this value in each
+            // selected cell. This mimics Excel's paste functionality, and works
+            // as a poor-man's fill-down.
+            if (rows.length === 1) {
+                var cellData = rows[0][0];
 
-                var existingRowData = self.data[realRowIndex];
-                var newRowData = Object.assign({}, existingRowData);
-
-                selections[realRowIndex] = [];
-
-                for (var colIndex = 0; colIndex < cells.length; colIndex++) {
-                    var column = schema[startColIndex + colIndex];
-
-                    if (!column) {
-                        console.warn("Paste data exceeded grid bounds. Skipping.");
-                        continue;
+                self.forEachSelectedCell(function (data, rowIndex, colName) {
+                    data[rowIndex][colName] = cellData;
+                });
+            } else {
+                for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+                    // Rows may have been moved by user, so get the actual row index
+                    // (instead of the row index at which the row is rendered):
+                    var realRowIndex = self.orders.rows[startRowIndex + rowIndex];
+                    var cells = rows[rowIndex];
+    
+                    var existingRowData = self.data[realRowIndex];
+                    var newRowData = Object.assign({}, existingRowData);
+    
+                    selections[realRowIndex] = [];
+    
+                    for (var colIndex = 0; colIndex < cells.length; colIndex++) {
+                        var column = schema[startColIndex + colIndex];
+    
+                        if (!column) {
+                            console.warn("Paste data exceeded grid bounds. Skipping.");
+                            continue;
+                        }
+        
+                        var columnName = column.name;
+                        var cellData = cells[colIndex];
+    
+                        if (cellData === undefined || cellData === null) {
+                            newRowData[columnName] = existingRowData[columnName];
+                            continue;
+                        }
+    
+                        selections[realRowIndex].push(startColIndex + colIndex);
+    
+                        newRowData[columnName] = cellData;
                     }
     
-                    var columnName = column.name;
-                    var cellData = cells[colIndex];
-
-                    if (cellData === undefined || cellData === null) {
-                        newRowData[columnName] = existingRowData[columnName];
-                        continue;
-                    }
-
-                    selections[realRowIndex].push(startColIndex + colIndex);
-
-                    newRowData[columnName] = cellData;
+                    self.data[realRowIndex] = newRowData;
                 }
-
-                self.data[realRowIndex] = newRowData;
             }
+
 
             self.selections = selections;
 


### PR DESCRIPTION
Mimics Excel's paste function, where copying a single cell and selecting multiple cells and pasting results in the single value being copied over _all_ selected cells.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/950979/92247923-38adb700-eec8-11ea-9614-2c7bfeef45ab.gif)

This does not cover all cases handled by Excel — I will cover those in future PRs.