### PR TITLE
Render a menu item in autocomplete filter dropdown to be able to filter blank column values

### DIFF
--- a/lib/contextMenu.js
+++ b/lib/contextMenu.js
@@ -279,9 +279,12 @@ define([], function () {
             }
             function fillAutoComplete() {
                 var count = 0;
+                const blankValues = [undefined, null, ''];
                 autoCompleteItems = {};
                 self.data.forEach(function (row) {
-                    var value = row[e.cell.header.name];
+                    const cellValue = row[e.cell.header.name];
+                    var value = blankValues.includes(cellValue) ? self.attributes.blanksText : cellValue;
+
                     if (autoCompleteItems[value] || count > self.attributes.maxAutoCompleteItems) { return; }
                     count += 1;
                     autoCompleteItems[value] = {

--- a/lib/contextMenu.js
+++ b/lib/contextMenu.js
@@ -267,7 +267,6 @@ define([], function () {
                 filterAutoCompleteButton = document.createElement('button'),
                 filterInput = document.createElement('input'),
                 n = e.cell && e.cell.header ? e.cell.header.title || e.cell.header.name : '',
-                autoCompleteItems,
                 iRect;
             function checkRegExpErrorState() {
                 filterInput.style.background = self.style.contextFilterInputBackground;
@@ -279,15 +278,17 @@ define([], function () {
             }
             function fillAutoComplete() {
                 var count = 0;
-                const blankValues = [undefined, null, ''];
-                autoCompleteItems = {};
-                self.data.forEach(function (row) {
-                    const cellValue = row[e.cell.header.name];
-                    var value = blankValues.includes(cellValue) ? self.attributes.blanksText : cellValue;
+                var items = {};
+                var blanksItem = [];
 
-                    if (autoCompleteItems[value] || count > self.attributes.maxAutoCompleteItems) { return; }
+                self.data.forEach(function (row) {
+                    var cellValue = row[e.cell.header.name] == null ? 
+                        row[e.cell.header.name] : String(row[e.cell.header.name]).trim();
+                    var value = self.blankValues.includes(cellValue) ? self.attributes.blanksText : cellValue;
+
+                    if (items[value] || count > self.attributes.maxAutoCompleteItems) { return; }
                     count += 1;
-                    autoCompleteItems[value] = {
+                    items[value] = {
                         title: self.formatters[e.cell.header.type || 'string']({ cell: { value: value }}),
                         click: function (e) {
                             filterInput.value = value;
@@ -298,13 +299,22 @@ define([], function () {
                         }
                     };
                 });
-                autoCompleteItems = Object.keys(autoCompleteItems).map(function (key) {
-                    return autoCompleteItems[key];
-                });
+
+                if (Object.keys(items).indexOf(self.attributes.blanksText) !== -1 ) {
+                    blanksItem.push(items[self.attributes.blanksText]);
+                    delete items[self.attributes.blanksText];
+                }
+
+                return blanksItem.concat(
+                    Object.keys(items).map(function (key) {
+                        return items[key];
+                    })
+                );
             }
+
             function createAutoCompleteContext(ev) {
                 if (ev && [40, 38, 13, 9].indexOf(ev.keyCode) !== -1) { return; }
-                fillAutoComplete();
+                var autoCompleteItems = fillAutoComplete();
                 iRect = filterInput.getBoundingClientRect();
                 if (autoCompleteContext) {
                     autoCompleteContext.dispose();

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,6 +18,7 @@ define([], function () {
                 ['allowSorting', true],
                 ['autoGenerateSchema', false],
                 ['autoResizeColumns', false],
+                ['blanksText', '(Blanks)'],
                 ['borderDragBehavior', 'none'],
                 ['borderResizeZone', 10],
                 ['clearSettingsOptionText', 'Clear saved settings'],

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -30,6 +30,7 @@
  * @param {boolean} [args.allowColumnReordering=true] - When true columns can be reordered.
  * @param {boolean} [args.allowMovingSelection=false] - When true selected data can be moved by clicking and dragging on the border of the selection.
  * @param {boolean} [args.allowRowReordering=false] - When true rows can be reordered.
+ * @param {string} [args.blanksText=(Blanks)] - The text that appears on the context menu for filtering blank values (i.e. `undefined`, `null`, `''`).
  * @param {string} [args.ellipsisText=...] - The text used as ellipsis text on truncated values.
  * @param {boolean} [args.allowSorting=true] - Allow user to sort rows by clicking on column headers.
  * @param {boolean} [args.showFilter=true] - When true, filter will be an option in the context menu.

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -454,6 +454,7 @@ define([], function () {
             self.webKit = /WebKit/.test(window.navigator.userAgent);
             self.moz = /Gecko/.test(window.navigator.userAgent);
             self.mobile = /Mobile/i.test(window.navigator.userAgent);
+            self.blankValues = [undefined, null, ''];
             self.cursorGrab = 'grab';
             self.cursorGrabing = 'grabbing';
             self.cursorGrab = self.webKit ? '-webkit-grab' : self.cursorGrab;
@@ -610,6 +611,8 @@ define([], function () {
                 });
             });
             self.filters.string = function (value, filterFor) {
+                if (filterFor === self.attributes.blanksText) return self.blankValues.includes(value);
+
                 value = String(value);
                 var filterRegExp,
                     regEnd = /\/(i|g|m)*$/,
@@ -630,6 +633,8 @@ define([], function () {
                     .indexOf(filterFor.toLocaleUpperCase()) !== -1 : false;
             };
             self.filters.number = function (value, filterFor) {
+                if (filterFor === self.attributes.blanksText) return self.blankValues.includes(value);
+
                 if (!filterFor) { return true; }
                 return value === filterFor;
             };

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -611,7 +611,11 @@ define([], function () {
                 });
             });
             self.filters.string = function (value, filterFor) {
-                if (filterFor === self.attributes.blanksText) return self.blankValues.includes(value);
+                if (filterFor === self.attributes.blanksText) {
+                    return self.blankValues.includes(
+                        value == null ? value : String(value).trim()
+                    );
+                }
 
                 value = String(value);
                 var filterRegExp,
@@ -633,7 +637,11 @@ define([], function () {
                     .indexOf(filterFor.toLocaleUpperCase()) !== -1 : false;
             };
             self.filters.number = function (value, filterFor) {
-                if (filterFor === self.attributes.blanksText) return self.blankValues.includes(value);
+                if (filterFor === self.attributes.blanksText) {
+                    return self.blankValues.includes(
+                        value == null ? value : String(value).trim()
+                    );
+                }
 
                 if (!filterFor) { return true; }
                 return value === filterFor;

--- a/test/tests.js
+++ b/test/tests.js
@@ -1058,6 +1058,30 @@
                     });
                     contextmenu(grid.canvas, 100, 37);
                 });
+                it('Autocomplete should have an option for filtering blank values', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [ 
+                            {col1: 'bar', col2: 0, col3: 'a'},
+                            {col1: '', col2: 1, col3: 'b'},
+                            {col1: 'baz', col2: 2, col3: 'c'},
+                        ],
+                    });
+                    grid.addEventListener('contextmenu', function (e) {
+                        setTimeout(function () {
+                            //HACK: get to filter input element in context menu
+                            var i = e.items[0].title.children[1];
+                            i.value = '';
+                            i.dispatchEvent(new Event('keyup'));
+                            const dropDownValues =  [...document.body.lastChild.childNodes].map(node => node.innerHTML);
+                            const containsBlanksText = dropDownValues.includes('(Blanks)');
+                            done(assertIf(
+                                !containsBlanksText,
+                                'Expected the autocomplete to have blanksText value item'));
+                        }, 1);
+                    });
+                    contextmenu(grid.canvas, 100, 37);
+                });
                 it('Should store JSON view state data, then clear it once clear settings is clicked.', function (done) {
                     var n = 'a' + (new Date().getTime()),
                         k = 'canvasDataGrid-' + n,
@@ -2512,6 +2536,33 @@
                     grid.setFilter('d', 'edfg');
                     done(assertIf(grid.data.length === 0 && grid.data[0].d === 'edfg',
                         'Expected filter to remove all but 1 row.'));
+                });
+                it('Should filter for blank values', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ d: 'abcd' }, { d: null }, { d: undefined }, { d: '' }, { d: 'edfg' }]
+                    });
+                    grid.setFilter('d', '(Blanks)');
+                    const filteredValuesOnly = grid.data.map(obj => obj.d);
+                    const onlyBlanks = filteredValuesOnly.length > 0 && filteredValuesOnly.every(item => [undefined, null, ''].includes(item))
+                    done(assertIf(
+                        !onlyBlanks,
+                        'Expected filter remove non-null/empty values'),
+                    );
+                });
+                it('Should filter for blank values (numbers)', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [{ d: 1 }, { d: null }, { d: undefined }, { d: '' }, { d: 2 }],
+                        schema: [{ name: 'd', type: 'number' }],
+                    });
+                    grid.setFilter('d', '(Blanks)');
+                    const filteredValuesOnly = grid.data.map(obj => obj.d);
+                    const onlyBlanks = filteredValuesOnly.length > 0 && filteredValuesOnly.every(item => [undefined, null, ''].includes(item))
+                    done(assertIf(
+                        !onlyBlanks,
+                        'Expected filter remove non-null/empty values'),
+                    );
                 });
                 it('Should remove all filters', function (done) {
                     var grid = g({

--- a/test/tests.js
+++ b/test/tests.js
@@ -1063,7 +1063,7 @@
                         test: this.test,
                         data: [ 
                             {col1: 'bar', col2: 0, col3: 'a'},
-                            {col1: '', col2: 1, col3: 'b'},
+                            {col1: '    ', col2: 1, col3: 'b'},
                             {col1: 'baz', col2: 2, col3: 'c'},
                         ],
                     });
@@ -1073,8 +1073,8 @@
                             var i = e.items[0].title.children[1];
                             i.value = '';
                             i.dispatchEvent(new Event('keyup'));
-                            const dropDownValues =  [...document.body.lastChild.childNodes].map(node => node.innerHTML);
-                            const containsBlanksText = dropDownValues.includes('(Blanks)');
+                            var firstDropdownValue = document.body.lastChild.childNodes[0].innerHTML;
+                            var containsBlanksText = firstDropdownValue === '(Blanks)';
                             done(assertIf(
                                 !containsBlanksText,
                                 'Expected the autocomplete to have blanksText value item'));
@@ -2540,11 +2540,11 @@
                 it('Should filter for blank values', function (done) {
                     var grid = g({
                         test: this.test,
-                        data: [{ d: 'abcd' }, { d: null }, { d: undefined }, { d: '' }, { d: 'edfg' }]
+                        data: [{ d: 'abcd' }, { d: null }, { d: undefined }, { d: '' }, { d: '       ' }, { d: 'edfg' }]
                     });
                     grid.setFilter('d', '(Blanks)');
-                    const filteredValuesOnly = grid.data.map(obj => obj.d);
-                    const onlyBlanks = filteredValuesOnly.length > 0 && filteredValuesOnly.every(item => [undefined, null, ''].includes(item))
+                    var filteredValuesOnly = grid.data.map(obj => obj.d);
+                    var onlyBlanks = filteredValuesOnly.length === 4 && filteredValuesOnly.every(item => [undefined, null, '', '       '].includes(item))
                     done(assertIf(
                         !onlyBlanks,
                         'Expected filter remove non-null/empty values'),
@@ -2557,8 +2557,8 @@
                         schema: [{ name: 'd', type: 'number' }],
                     });
                     grid.setFilter('d', '(Blanks)');
-                    const filteredValuesOnly = grid.data.map(obj => obj.d);
-                    const onlyBlanks = filteredValuesOnly.length > 0 && filteredValuesOnly.every(item => [undefined, null, ''].includes(item))
+                    var filteredValuesOnly = grid.data.map(obj => obj.d);
+                    var onlyBlanks = filteredValuesOnly.length === 3 && filteredValuesOnly.every(item => [undefined, null, ''].includes(item))
                     done(assertIf(
                         !onlyBlanks,
                         'Expected filter remove non-null/empty values'),


### PR DESCRIPTION
Replaces PR #297 as I messed up commit-history in my forked repo branch while making a couple of improvements.

I noticed that blank cell values show up as items in the autocomplete filter dropdown menu, however they are invisible. 

Excel, for example, has a `(Blanks)` menu item which allows you filter on blank column values:

![image](https://user-images.githubusercontent.com/101284/92453807-0057f280-f1c0-11ea-822d-8f30a34e0131.png)

This PR adds a menu item (defaults to`(Blanks)` keeping in line with Excel) to the dropdown to enable filtering on blank column values (if present in the column). Blank column values are `null`, `undefined` and an empty string (i.e. with zero or more spaces)

![image](https://user-images.githubusercontent.com/101284/92581705-4c726800-f290-11ea-91f0-ad13dc895475.png)

The value of the menu item can be customised using the attribute `blanksText`.