### PR TITLE
Fix copy/paste of cells in canvas-datagrid on Windows

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1152,7 +1152,7 @@ define([], function () {
                 if (mimeType === "text/html") {
                     // strip table beginning and ending off, then split at rows
                     var cleanedHtmlData = data.substring(
-                        data.indexOf('<table><tr>') + 11, data.length - 13
+                        data.indexOf('<table><tr>') + 11, data.indexOf('</tr></table>')
                     ).split('</tr><tr>').filter(
                         // ditch any headers on the table
                         row => !/^<th>|^<thead>/.test(row)

--- a/lib/events.js
+++ b/lib/events.js
@@ -1137,13 +1137,13 @@ define([], function () {
         self.pasteData = function(pasteValue, mimeType, startRowIndex, startColIndex) {
             var schema = self.getVisibleSchema();
 
-            const isSupportedHtmlTable = htmlString => /^(<meta[^>]+>)?<table>/.test(htmlString.substring(0, 29));
+            const isSupportedHtmlTable = htmlString => /(?:^(<meta[^>]+>)?<table>)|(?:<!--StartFragment-->.?)/.test(htmlString);
 
             // TODO: support pasting tables from Excel 
             if (mimeType === "text/html" && isSupportedHtmlTable(pasteValue) === false) {
                 console.warn('Unrecognized HTML format. HTML must be a simple table, e.g.: <table><tr><td>data</td></tr></table>.');
                 console.warn('Data with the mime type text/html not in this format will not be imported as row data.');
-
+                
                 return;
             }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -1137,7 +1137,7 @@ define([], function () {
         self.pasteData = function(pasteValue, mimeType, startRowIndex, startColIndex) {
             var schema = self.getVisibleSchema();
 
-            const isSupportedHtmlTable = htmlString => /(?:^(<meta[^>]+>)?<table>)|(?:<!--StartFragment-->.?)/.test(htmlString);
+            const isSupportedHtmlTable = htmlString => /(?:^(<meta[^>]+>)?<table>)|(?:<!--StartFragment-->\s*<table>)/.test(htmlString);
 
             // TODO: support pasting tables from Excel 
             if (mimeType === "text/html" && isSupportedHtmlTable(pasteValue) === false) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1596,7 +1596,7 @@
                                 {
                                     type: 'text/html',
                                     getAsString: function(callback) {
-                                        callback("<html> <body> <!--StartFragment--><table><tr><td>Paste buffer value</td></tr></table><!--EndFragment--> </body> </html>");
+                                        callback('<html> <body> <!--StartFragment--><table><tr><td>Paste buffer value</td></tr></table><!--EndFragment--> </body> </html>');
                                     }
                                 }
                             ]

--- a/test/tests.js
+++ b/test/tests.js
@@ -1578,6 +1578,36 @@
                         done(assertIf(cellData !== 'Paste buffer value', 'Value has not been replaced with clipboard data: ' + cellData));
                     }, 10);
                 });
+                it('Should paste a CF_HTML value from the clipboard into a cell', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            { 'Column A': 'Original value' }
+                        ]
+                    });
+
+                    grid.focus();
+                    grid.setActiveCell(0, 0);
+                    grid.selectArea({ top: 0, left: 0, bottom: 0, right: 0 });
+
+                    grid.paste({
+                        clipboardData: {
+                            items: [
+                                {
+                                    type: 'text/html',
+                                    getAsString: function(callback) {
+                                        callback("<html> <body> <!--StartFragment--><table><tr><td>Paste buffer value</td></tr></table><!--EndFragment--> </body> </html>");
+                                    }
+                                }
+                            ]
+                        }
+                    });
+
+                    setTimeout(function() {
+                        var cellData = grid.data[0]['Column A'];
+                        done(assertIf(cellData !== 'Paste buffer value', 'Value has not been replaced with clipboard data: ' + cellData));
+                    }, 10);
+                });
                 it("Should fire a beforepaste event", function (done) {
                     var grid = g({
                         test: this.test,


### PR DESCRIPTION
This PR changes the regex checking for supported HTML to also match the format coming back from the Windows clipboard. 

It resolves issue #300.