### PR TITLE
Add autoResizeRows attribute for optionally resizing rows to fit wrapped text

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,6 +18,7 @@ define([], function () {
                 ['allowSorting', true],
                 ['autoGenerateSchema', false],
                 ['autoResizeColumns', false],
+                ['autoResizeRows', false],
                 ['blanksText', '(Blanks)'],
                 ['borderDragBehavior', 'none'],
                 ['borderResizeZone', 10],

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -39,6 +39,7 @@
  * @param {boolean} [args.singleSelectionMode=false] - When true, selections will ignore the command/control key. Conflicts with persistantSelectionMode.
  * @param {string} [args.selectionMode='cell'] - Can be 'cell', or 'row'.  This setting dictates what will be selected when the user clicks a cell.  The cell, or the entire row respectively.
  * @param {boolean} [args.autoResizeColumns=false] - When true, all columns will be automatically resized to fit the data in them. Warning! Expensive for large (&gt;100k ~2 seconds) datasets.
+ * @param {boolean} [args.autoResizeRows=false] - When true, rows will be automatically resized to fit the data in them if text-wrapping is enabled.
  * @param {boolean} [args.allowRowHeaderResize=true] - When true, the user can resize the width of the row headers.
  * @param {boolean} [args.allowColumnResize=true] - When true, the user can resize the width of the columns.
  * @param {boolean} [args.allowRowResize=true] - When true, the user can resize the row headers increasing the height of the row.

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -299,6 +299,7 @@ define([], function () {
                 lines = [],
                 out = [],
                 wrap = self.style.cellWhiteSpace !== 'nowrap',
+                autoResize = self.attributes.autoResizeRows && wrap,
                 elWidth,
                 et = self.attributes.ellipsisText,
                 elClipLength,
@@ -339,7 +340,7 @@ define([], function () {
                     lines.push(line);
                 }
                 textHeight += cell.calculatedLineHeight;
-                if (textHeight > cHeight) {
+                if (textHeight > cHeight && !autoResize) {
                     if (lines.length === 0) { break; }
                     elClipLength = 1;
                     previousLine = lines[lines.length - 1];
@@ -832,6 +833,10 @@ define([], function () {
                                     drawHtml(cell);
                                 } else {
                                     drawText(cell);
+                                }
+                                
+                                if (wrap && cell.text && cell.text.height > rowHeight) {
+                                    self.sizes.rows[isHeader ? -1 : rowIndex] = cell.text.height;
                                 }
                             }
                         }

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -616,6 +616,7 @@ define([], function () {
                         isCorner = /cornerCell/.test(cellStyle),
                         isRowHeader = 'rowHeaderCell' === cellStyle,
                         isColumnHeader = 'columnHeaderCell' === cellStyle,
+                        wrap = self.style.cellWhiteSpace !== 'nowrap',
                         selected = self.selections[rowOrderIndex] && self.selections[rowOrderIndex].indexOf(columnOrderIndex) !== -1,
                         hovered = self.hovers.rowIndex === rowOrderIndex && self.hovers.columnIndex === columnOrderIndex,
                         active = self.activeCell.rowIndex === rowOrderIndex && self.activeCell.columnIndex === columnOrderIndex,
@@ -834,7 +835,7 @@ define([], function () {
                                 } else {
                                     drawText(cell);
                                 }
-                                
+
                                 if (wrap && cell.text && cell.text.height > rowHeight) {
                                     self.sizes.rows[isHeader ? -1 : rowIndex] = cell.text.height;
                                 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -2685,6 +2685,71 @@
                 });
             });
             describe('Attributes', function () {
+                it('Should have one row in cell if text-wrapping enabled but rows are not auto resized', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            {col1: 'This is a very long value which we expect to be wrapped on multiple lines',},
+                        ],
+                        style: {
+                            cellWhiteSpace: 'normal'
+                        }
+                    });
+                    var cell = grid.getVisibleCellByIndex(0,0)
+                    
+                    
+                    var lineCount = cell.text.lines.length;
+                    done(
+                        assertIf(lineCount !== 1, 'Expected 1 wrapped lines, got', lineCount)
+                    );
+                });
+
+                it('Should have multiple rows in cell after resize', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            {col1: 'This is a very long value which we expect to be wrapped on multiple lines',},
+                        ],
+                        style: {
+                            cellWhiteSpace: 'normal'
+                        }
+                    });
+                    setTimeout(function () {
+                        grid.focus();
+                        mousemove(grid.canvas, 10, 48);
+                        mousedown(grid.canvas, 10, 48);
+                        mousemove(grid.canvas, 10, 160, grid.canvas);
+                        mousemove(document.body, 10, 160, grid.canvas);
+                        mouseup(document.body, 10, 160, grid.canvas);
+
+                        var cell = grid.getVisibleCellByIndex(0,0)
+                        var lineCount = cell.text.lines.length;
+
+                        done(
+                            assertIf(lineCount !== 3, 'Expected 3 wrapped lines after resize, got %s', lineCount)
+                        );
+                    }, 10);
+                });
+
+                it('Should auto resize row if text-wrapping is enabled', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: [
+                            {col1: 'This is a very long row which we expect to be wrapped on multiple lines',},
+                        ],
+                        style: {
+                            cellWhiteSpace: 'normal'
+                        },
+                        autoResizeRows: true,
+                    });
+                    var cell = grid.getVisibleCellByIndex(0,0)
+                    var lineCount = cell.text.lines.length;
+                    
+                    done(
+                        assertIf(lineCount !== 3, 'Expected 3 wrapped lines, got %s', lineCount)
+                    )
+                });
+
                 it('Should store JSON view state data when a name is passed and view state is altered.', function (done) {
                     var n = 'a' + (new Date().getTime()),
                         k = 'canvasDataGrid-' + n,


### PR DESCRIPTION
Add an attribute `autoResizeRows` which, if set to `true`, will cause automatic resize of rows that have multiline, text-wrapped cell values in them.

It addresses #134