### PR TITLE
Make distinction between "enter" and "edit" modes

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -20,7 +20,7 @@
  * @param {boolean} [args.showNewRow=true] - When true, a row will appear at the bottom of the data set. schema[].defaultValue will define a default value for each cell. defaultValue can be a string or a function. When a function is used, the arguments header and index will be passed to the function. The value returned by the function will be the value in the new cell.  See {@link canvasDatagrid.header.defaultValue}
  * @param {boolean} [args.saveAppearance=true] - When true, and the attribute name is set, column and row sizes will be saved to the browser's localStore.
  * @param {boolean} [args.selectionFollowsActiveCell=false] - When true, moving the active cell with keystrokes will also change the selection.
- * @param {boolean} [args.multiLine=false] - When true, edit cells will be textareas, when false edit cells will be inputs.  See {@link tutorial--Use-a-textarea-to-edit-cells-instead-of-an-input.}
+ * @param {boolean} [args.multiLine=false] - When true, edit cells will allow multiple lines (with Alt+Enter), when false edit cells will only allow single line entries.  See {@link tutorial--Use-a-textarea-to-edit-cells-instead-of-an-input.}
  * @param {boolean} [args.globalRowResize=false] - When true, resizing a row will resize all rows to the same height.
  * @param {boolean} [args.editable=true] - When true, cells can be edited. When false, grid is read only to the user.
  * @param {string} [args.borderDragBehavior='none'] - Can be set to 'resize', 'move', or 'none'.  If set to 'move', `allowMovingSelection` should also be set true.  If set to 'resize', `allowRowResizeFromCell` and/or `allowColumnResizeFromCell` should be set true.

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -283,12 +283,13 @@ define([], function () {
                     self.endEdit(true); // end edit and abort the value change
                     self.draw(true);
                 } else if (e.key === "Enter"
-                        && (!self.attributes.multiLine
-                            || (self.attributes.multiLine && e.shiftKey))) {
+                        && ((self.attributes.multiLine && e.altKey) === false)) {
                     self.endEdit();
 
-                    // Move to cell in next row
-                    var nextRowIndex = Math.min(ny + 1, self.data.length - 1);
+                    // Move to cell in next or previous row
+                    var nextRowIndex = e.shiftKey ?
+                        Math.max(0, ny - 1)
+                        : Math.min(ny + 1, self.data.length - 1);
 
                     if (nextRowIndex !== ny) {
                         self.scrollIntoView(nx, nextRowIndex);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -188,8 +188,12 @@ define([], function () {
          * @method
          * @param {number} x The column index of the cell to edit.
          * @param {number} y The row index of the cell to edit.
+         * @param {boolean} inEnterMode If true, starting to type in cell will replace the
+         * cell's previous value instead of appending, and using the arrow keys will allow
+         * the user to navigate to adjacent cells instead of moving the text cursor around
+         * (default is false, and means user is in 'edit' mode).
          */
-        self.beginEditAt = function (x, y, NativeEvent) {
+        self.beginEditAt = function (x, y, NativeEvent, inEnterMode = false) {
             if (!self.attributes.editable) { return; }
             if (self.input) {
                 self.endEdit();
@@ -261,7 +265,11 @@ define([], function () {
             self.resizeEditInput();
             self.input.style.zIndex = self.style.editCellZIndex;
             self.input.style.fontSize = (parseInt(self.style.editCellFontSize, 10) * self.scale) + 'px';
-            self.input.value = [null, undefined].indexOf(cell.value) !== -1 ? '' : cell.value;
+
+            var cellValueIsEmpty = [null, undefined].indexOf(cell.value) !== -1;
+            var shouldClearCellValue = cellValueIsEmpty || inEnterMode;
+
+            self.input.value = shouldClearCellValue ? '' : cell.value;
             self.input.focus();
             self.input.addEventListener('click', self.stopPropagation);
             self.input.addEventListener('dblclick', self.stopPropagation);
@@ -272,7 +280,7 @@ define([], function () {
                     ny = cell.rowIndex;
 
                 if (e.key === "Escape") {
-                    self.endEdit(true);
+                    self.endEdit(true); // end edit and abort the value change
                     self.draw(true);
                 } else if (e.key === "Enter"
                         && (!self.attributes.multiLine
@@ -288,7 +296,7 @@ define([], function () {
                     }
 
                     self.draw(true);
-                } else if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) {
+                } else if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key) && inEnterMode) {
                     switch (e.key) {
                         case "ArrowUp":
                             ny = Math.max(0, ny - 1);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -282,8 +282,10 @@ define([], function () {
                 if (e.key === "Escape") {
                     self.endEdit(true); // end edit and abort the value change
                     self.draw(true);
-                } else if (e.key === "Enter"
-                        && ((self.attributes.multiLine && e.altKey) === false)) {
+                } else if (e.key === "Enter" && self.attributes.multiLine && e.altKey) {
+                    self.input.value = self.input.value + "\n";
+                    self.input.scrollTop = self.input.scrollHeight;
+                } else if (e.key === "Enter") {
                     self.endEdit();
 
                     // Move to cell in next or previous row

--- a/lib/events.js
+++ b/lib/events.js
@@ -969,7 +969,7 @@ define([], function () {
 
             // If a user starts typing content, immediately enter edit mode
             if (isPrintableKeyEvent(e) && !ctrl) {
-                return self.beginEditAt(x, y, e);
+                return self.beginEditAt(x, y, e, true);
             }
 
             if (self.attributes.showNewRow) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -967,7 +967,7 @@ define([], function () {
                 return;
             }
 
-            // If a user starts typing content, immediately enter edit mode
+            // If a user starts typing content, switch to "Enter" mode
             if (isPrintableKeyEvent(e) && !ctrl) {
                 return self.beginEditAt(x, y, e, true);
             }
@@ -1010,6 +1010,7 @@ define([], function () {
             }
 
             if (e.key === "Enter") {
+                e.preventDefault();
                 return self.beginEditAt(x, y, e);
             }
 


### PR DESCRIPTION
Excel and Google Sheets have a notion of "Enter" and "Edit" modes for manipulating a cell's data:

- "Enter" mode is activated when a user starts typing in the active cell. This typing replaces the cell's previous value, and allow the user to quickly navigate to adjacent cells using the arrow keys. This allows you to enter a series of values very quickly.
- "Edit" mode is when you hit the "Enter" key (confusing, no?) to edit the cell's value. It places the text cursor at the end of the cell's content, and arrow keys do not move away from the active cell, but instead move the text cursor around. This mode is intended for more deliberate editing of existing values.

canvas-datagrid previously didn't make a clear distinction, so there was a bug when you started typing in a cell and then attempted to use the arrow keys to move the cursor, which left the cell instead. There was no way to navigate within the cell's text contents.

This pull request makes the distinction more explicit. When you hit "Enter" you're in `edit` mode and you can edit the cell's existing contents, and can move the cursor around with the arrow keys. In contrast, by just typing in a cell, as in Excel or Google Sheets, you replace the cell's contents. Using the arrows keys will move the active cell.