### PR TITLE
Fix webcomponent data and schema attributes

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -125,11 +125,11 @@ define(['./defaults'], function (defaults) {
                 if (intf.dataType === 'application/x-canvas-datagrid') {
                     intf.dataType = 'application/json+x-canvas-datagrid';
                 }
-                intf.args.data = newVal;
+                intf.data = newVal;
                 return;
             }
             if (attrName === 'schema') {
-                intf.args.schema = typeMap.schema(newVal);
+                intf.schema = typeMap.schema(newVal);
                 return;
             }
             if (attrName === 'name') {


### PR DESCRIPTION
`component.attributeChangedCallback` is always called after the Grid initialisation. Thus initialisation of the `canvas-datagrid ` webcomponent with a schema fails, as args is only respected during the initialisation phase. The bug can be tested like that 

```js
 <canvas-datagrid class="myGridStyle" selectionmode="row" autogenerateschema="false"
        schema='[{"name":"title", "title":"The Title"}, {"name":"description", "title":"The Description"}, {"name":"foo", "title":"The Foo"}]'>
        [
            {"title": "row 1 column 1", "description":"row 1 column 2","foo":"row 1 column 3"},
            {"title": "row 1 column 1", "description":"row 1 column 2","foo":"row 1 column 3"}
        ]
</canvas-datagrid>
```

If schema is not applied the titles are auto generated and all lowercase.