### PR TITLE
Fix getHeaderWidth() return value

### DIFF
--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -1108,7 +1108,7 @@ define([], function () {
          */
         self.getHeaderWidth = function () {
             return self.getVisibleSchema().reduce(function (total, header) {
-                return total + parseInt(header.width || self.style.cellWidth);
+                return total + parseInt(header.width || self.style.cellWidth, 10);
             }, 0);
         };
         /**

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -1108,7 +1108,7 @@ define([], function () {
          */
         self.getHeaderWidth = function () {
             return self.getVisibleSchema().reduce(function (total, header) {
-                return total + (header.width || self.style.cellWidth);
+                return total + parseInt(header.width || self.style.cellWidth);
             }, 0);
         };
         /**


### PR DESCRIPTION
getHeaderWidth() concatenates a string instead of summing up the column widths.