### PR TITLE
Fix bug that causes current selections to be overwritten when cell on only 1 row is selected

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1170,7 +1170,6 @@ define([], function () {
             }
 
             var rows = parseData(pasteValue, mimeType);
-            var selections = [];
 
             // Special case: if rows.length = 1, we paste this value in each
             // selected cell. This mimics Excel's paste functionality, and works
@@ -1182,6 +1181,7 @@ define([], function () {
                     data[rowIndex][colName] = cellData;
                 });
             } else {
+                var selections = [];
                 for (var rowIndex = 0; rowIndex < rows.length; rowIndex++) {
                     // Rows may have been moved by user, so get the actual row index
                     // (instead of the row index at which the row is rendered):
@@ -1216,15 +1216,13 @@ define([], function () {
     
                     self.data[realRowIndex] = newRowData;
                 }
+                self.selections = selections;
             }
-
-
-            self.selections = selections;
 
             // selections is a sparse array, so we condense:
             var affectedCells = [];
 
-            selections.forEach(function (row, rowIndex) {
+            self.selections.forEach(function (row, rowIndex) {
                 if (rowIndex === undefined) return;
 
                 row.forEach(function (columnIndex) {


### PR DESCRIPTION
PR fixes following issue: When copy/pasting a cell from only 1 row, `affectedCells` will not get passed onto the `afterpaste` event. This is caused by the re-assignment of `self.selections` with an empty `selections` array which is only populated in the situation where we are copying multiple rows of data.
