### PR TITLE
Fix grid not resizing when `autoResizeRows` is enabled

### DIFF
--- a/lib/draw.js
+++ b/lib/draw.js
@@ -838,6 +838,7 @@ define([], function () {
 
                                 if (wrap && cell.text && cell.text.height > rowHeight) {
                                     self.sizes.rows[isHeader ? -1 : rowIndex] = cell.text.height;
+                                    checkScrollHeight = true;
                                 }
                             }
                         }


### PR DESCRIPTION
Trigger a resize of the grid when row height has changed due to wrapping cell contents.