### PR TITLE
Fix: Missing function constructor parameter

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -172,7 +172,7 @@ export default function () {
       return;
     }
     if (/^on/.test(attrName)) {
-      intf.addEventListener('on' + attrName, Function(newVal));
+      intf.addEventListener('on' + attrName, Function('e', newVal));
     }
     return;
   };


### PR DESCRIPTION
Fixes #322

@ndrsn 
The tests didn't catch it, but the function constructor needs to have the name of the parameter populated.
I'm not sure how it's absence will break user code, but it seems like it would be likely to.
