### PR TITLE
fix: use 'selectNone' on escape so selectionchanged event will be dis…

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1239,8 +1239,7 @@ export default function (self) {
     }
 
     if (e.key === 'Escape') {
-      self.selections = [];
-      self.draw(true);
+      self.selectNone();
     } else if (ctrl && e.key === 'a') {
       self.selectAll();
     } else if (e.key === 'ArrowDown') {

--- a/test/tests.js
+++ b/test/tests.js
@@ -2345,6 +2345,24 @@
                         });
                     }, 100);
                 });
+                it('Should dispatch a `selectionchanged` event on esc', function (done) {
+                    var grid = g({
+                        test: this.test,
+                        data: smallData()
+                    });
+                    grid.focus();
+                    grid.addEventListener('selectionchanged', function (event) {
+                        try {
+                            doAssert(event.selections.length === 0, "selection is empty");
+                        } catch (error) {
+                            done(error);
+                        }
+
+                        done();
+                    });
+                    de(grid.controlInput, 'keydown', {key: "Escape"});
+                });
+
                 it('Should select a row', function (done) {
                     var grid = g({
                         test: this.test,


### PR DESCRIPTION
When clearing the selection via Escape there won't be a `selectionchanged ` event dispatched. 

By calling  `selectNone `, analogous to `ctrl + a` with  `selectAll `, the missing event will be dispatched.