### PR TITLE
Split original source data from viewed data

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
 
     // frameworks to use
     // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha'],
+    frameworks: ['mocha', 'chai'],
 
     // list of files / patterns to load in the browser
     files: [

--- a/lib/contextMenu.js
+++ b/lib/contextMenu.js
@@ -367,7 +367,7 @@ export default function (self) {
       var items = {};
       var blanksItem = [];
 
-      self.data.forEach(function (row) {
+      self.viewData.forEach(function (row) {
         var cellValue =
           row[e.cell.header.name] == null
             ? row[e.cell.header.name]

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -201,8 +201,8 @@ export default function (self) {
       self.changes[y] = self.changes[y] || {};
       self.changes[y][cell.header.name] = self.input.value;
       if (!cell.data) {
-        self.data[cell.rowIndex] = {};
-        cell.data = self.data[cell.rowIndex];
+        self.originalData[cell.rowIndex] = {};
+        cell.data = self.originalData[cell.rowIndex];
       }
       cell.data[cell.header.name] = self.input.value;
       if (y === self.viewData.length) {
@@ -369,7 +369,7 @@ export default function (self) {
         // Move to cell in next or previous row
         var nextRowIndex = e.shiftKey
           ? Math.max(0, ny - 1)
-          : Math.min(ny + 1, self.data.length - 1);
+          : Math.min(ny + 1, self.viewData.length - 1);
 
         if (nextRowIndex !== ny) {
           self.scrollIntoView(nx, nextRowIndex);
@@ -386,7 +386,7 @@ export default function (self) {
             ny = Math.max(0, ny - 1);
             break;
           case 'ArrowDown':
-            ny = Math.min(ny + 1, self.data.length - 1);
+            ny = Math.min(ny + 1, self.viewData.length - 1);
             break;
           case 'ArrowLeft':
             nx = Math.max(nx - 1, 0);
@@ -421,9 +421,9 @@ export default function (self) {
           ny += 1;
         }
         if (ny < 0) {
-          ny = self.data.length - 1;
+          ny = self.viewData.length - 1;
         }
-        if (ny > self.data.length - 1) {
+        if (ny > self.viewData.length - 1) {
           ny = 0;
         }
         self.scrollIntoView(nx, ny);

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -205,7 +205,7 @@ export default function (self) {
         cell.data = self.data[cell.rowIndex];
       }
       cell.data[cell.header.name] = self.input.value;
-      if (y === self.data.length) {
+      if (y === self.viewData.length) {
         if (
           self.dispatchEvent('newrow', {
             value: self.input.value,

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -201,8 +201,8 @@ export default function (self) {
       self.changes[y] = self.changes[y] || {};
       self.changes[y][cell.header.name] = self.input.value;
       if (!cell.data) {
-        self.originalData[cell.rowIndex] = {};
-        cell.data = self.originalData[cell.rowIndex];
+        self.originalData[cell.boundRowIndex] = {};
+        cell.data = self.originalData[cell.boundRowIndex];
       }
       cell.data[cell.header.name] = self.input.value;
       if (y === self.viewData.length) {

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -897,10 +897,17 @@ export default function (self) {
           isRowHeader: isRowHeader,
           rowOpen: rowOpen,
           header: header,
+
           columnIndex: columnOrderIndex,
           rowIndex: rowOrderIndex,
+
+          // TODO: set correct value
+          viewRowIndex: null,
+          viewColumnIndex: null,
+
           sortColumnIndex: headerIndex,
           sortRowIndex: rowIndex,
+
           isGrid: isGrid,
           isNormal: !isGrid && !isCorner && !isHeader,
           gridId: (self.attributes.name || '') + rowIndex + ':' + headerIndex,

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -570,7 +570,7 @@ export default function (self) {
       w,
       s,
       rowIndex,
-      rd,
+      rowData,
       aCell,
       viewData = self.viewData || [],
       bc = self.style.gridBorderCollapse === 'collapse',
@@ -1210,7 +1210,7 @@ export default function (self) {
       if (y - cellHeight * 2 > h) {
         return false;
       }
-      rd = viewData[rowOrderIndex];
+      rowData = viewData[rowOrderIndex];
       rowOpen = self.openChildren[rowOrderIndex];
       rowSansTreeHeight =
         (self.sizes.rows[rowOrderIndex] || self.style.cellHeight) * self.scale;
@@ -1226,7 +1226,7 @@ export default function (self) {
       //draw normal columns
       for (o = self.scrollIndexLeft; o < g; o += 1) {
         i = self.orders.columns[o];
-        x += drawCell(rd, rowOrderIndex, rowIndex)(s[i], i, o);
+        x += drawCell(rowData, rowOrderIndex, rowIndex)(s[i], i, o);
         if (x > self.width) {
           self.scrollIndexRight = o;
           self.scrollPixelRight = x;
@@ -1240,7 +1240,7 @@ export default function (self) {
       }
       for (o = 0; o < self.frozenColumn; o += 1) {
         i = self.orders.columns[o];
-        x += drawCell(rd, rowOrderIndex, rowIndex)(s[i], i, o);
+        x += drawCell(rowData, rowOrderIndex, rowIndex)(s[i], i, o);
         if (x > self.width) {
           break;
         }
@@ -1285,7 +1285,7 @@ export default function (self) {
         treeGrid.parentNode.offsetHeight = 0;
         delete self.sizes.trees[rowOrderIndex];
       }
-      rowHeaders.push([rd, rowOrderIndex, rowIndex, y, rowHeight]);
+      rowHeaders.push([rowData, rowOrderIndex, rowIndex, y, rowHeight]);
       self.visibleRowHeights[rowOrderIndex] = rowHeight;
       y += cellHeight + (bc ? 0 : self.style.cellBorderWidth);
       return true;

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1201,7 +1201,7 @@ export default function (self) {
         }
       }
     }
-    function drawRow(r, rowIndex) {
+    function drawRow(rowOrderIndex, rowIndex) {
       var i,
         treeHeight,
         rowSansTreeHeight,
@@ -1210,11 +1210,11 @@ export default function (self) {
       if (y - cellHeight * 2 > h) {
         return false;
       }
-      rd = viewData[r];
-      rowOpen = self.openChildren[r];
+      rd = viewData[rowOrderIndex];
+      rowOpen = self.openChildren[rowOrderIndex];
       rowSansTreeHeight =
-        (self.sizes.rows[r] || self.style.cellHeight) * self.scale;
-      treeHeight = (rowOpen ? self.sizes.trees[r] : 0) * self.scale;
+        (self.sizes.rows[rowOrderIndex] || self.style.cellHeight) * self.scale;
+      treeHeight = (rowOpen ? self.sizes.trees[rowOrderIndex] : 0) * self.scale;
       rowHeight = rowSansTreeHeight + treeHeight;
       if (y < -rowHeight) {
         return false;
@@ -1226,7 +1226,7 @@ export default function (self) {
       //draw normal columns
       for (o = self.scrollIndexLeft; o < g; o += 1) {
         i = self.orders.columns[o];
-        x += drawCell(rd, r, rowIndex)(s[i], i, o);
+        x += drawCell(rd, rowOrderIndex, rowIndex)(s[i], i, o);
         if (x > self.width) {
           self.scrollIndexRight = o;
           self.scrollPixelRight = x;
@@ -1240,7 +1240,7 @@ export default function (self) {
       }
       for (o = 0; o < self.frozenColumn; o += 1) {
         i = self.orders.columns[o];
-        x += drawCell(rd, r, rowIndex)(s[i], i, o);
+        x += drawCell(rd, rowOrderIndex, rowIndex)(s[i], i, o);
         if (x > self.width) {
           break;
         }
@@ -1253,8 +1253,8 @@ export default function (self) {
         self.scrollPixelLeft +
         self.style.cellBorderWidth;
       // don't draw a tree for the new row
-      treeGrid = self.childGrids[r];
-      if (r !== viewData.length && rowOpen) {
+      treeGrid = self.childGrids[rowOrderIndex];
+      if (rowOrderIndex !== viewData.length && rowOpen) {
         treeGrid.visible = true;
         treeGrid.parentNode = {
           offsetTop: y + rowSansTreeHeight + self.canvasOffsetTop,
@@ -1268,10 +1268,10 @@ export default function (self) {
           nodeType: 'canvas-datagrid-tree',
           scrollTop: self.scrollBox.scrollTop,
           scrollLeft: self.scrollBox.scrollLeft,
-          rowIndex: r,
+          rowIndex: rowOrderIndex,
         };
         self.visibleCells.unshift({
-          rowIndex: r,
+          rowIndex: rowOrderIndex,
           columnIndex: 0,
           y: treeGrid.parentNode.offsetTop,
           x: treeGrid.parentNode.offsetLeft,
@@ -1283,10 +1283,10 @@ export default function (self) {
         treeGrid.draw();
       } else if (treeGrid) {
         treeGrid.parentNode.offsetHeight = 0;
-        delete self.sizes.trees[r];
+        delete self.sizes.trees[rowOrderIndex];
       }
-      rowHeaders.push([rd, r, rowIndex, y, rowHeight]);
-      self.visibleRowHeights[r] = rowHeight;
+      rowHeaders.push([rd, rowOrderIndex, rowIndex, y, rowHeight]);
+      self.visibleRowHeights[rowOrderIndex] = rowHeight;
       y += cellHeight + (bc ? 0 : self.style.cellBorderWidth);
       return true;
     }

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -785,7 +785,7 @@ export default function (self) {
         }
       }
     }
-    function drawCell(d, rowOrderIndex, rowIndex) {
+    function drawCell(rowData, rowOrderIndex, rowIndex) {
       return function drawEach(header, headerIndex, columnOrderIndex) {
         if (header.hidden) {
           return 0;
@@ -808,7 +808,7 @@ export default function (self) {
             self.activeCell.rowIndex === rowOrderIndex &&
             self.activeCell.columnIndex === columnOrderIndex,
           isColumnHeaderCellCap = cellStyle === 'columnHeaderCellCap',
-          rawValue = d ? d[header.name] : undefined,
+          rawValue = rowData ? rowData[header.name] : undefined,
           isGrid = header.type === 'canvas-datagrid',
           activeHeader =
             (self.orders.rows[self.activeCell.rowIndex] === rowOrderIndex ||
@@ -826,7 +826,7 @@ export default function (self) {
           cellWidth = self.sizes.columns[headerIndex] || header.width,
           ev = {
             value: rawValue,
-            row: d,
+            row: rowData,
             header: header,
           };
         if (isColumnHeaderCellCap) {
@@ -889,7 +889,7 @@ export default function (self) {
           offsetHeight: cellHeight,
           parentNode: self.intf.parentNode,
           offsetParent: self.intf.parentNode,
-          data: d,
+          data: rowData,
           isCorner: isCorner,
           isHeader: isHeader,
           isColumnHeader: isColumnHeader,

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -568,7 +568,7 @@ export default function (self) {
       c,
       h,
       w,
-      s,
+      schema,
       rowIndex,
       rowData,
       aCell,
@@ -774,7 +774,7 @@ export default function (self) {
         }
         if (
           !self.selections[cell.rowIndex + -offsetPoint.y] ||
-          cell.columnIndex === s.length ||
+          cell.columnIndex === schema.length ||
           self.selections[cell.rowIndex + -offsetPoint.y].indexOf(
             cell.columnIndex + 1 + -offsetPoint.x,
           ) === -1
@@ -1086,10 +1086,10 @@ export default function (self) {
         return cell.width;
       };
     }
-    function drawRowHeader(rowData, index, rowOrderIndex) {
+    function drawRowHeader(rowData, rowIndex, rowOrderIndex) {
       if (self.attributes.showRowHeaders) {
         x = 0;
-        const i = index + 1;
+        const i = rowIndex + 1;
         const rowHeaderCell = { rowHeaderCell: i };
         const headerDescription = {
           name: 'rowHeaderCell',
@@ -1099,8 +1099,8 @@ export default function (self) {
           data: i,
           index: -1,
         };
-        rowOpen = self.openChildren[index];
-        drawCell(rowHeaderCell, index, rowOrderIndex)(
+        rowOpen = self.openChildren[rowIndex];
+        drawCell(rowHeaderCell, rowOrderIndex, rowIndex)(
           headerDescription,
           -1,
           -1,
@@ -1109,7 +1109,7 @@ export default function (self) {
     }
     function drawHeaders() {
       var d,
-        g = s.length,
+        g = schema.length,
         i,
         o,
         columnHeaderCell,
@@ -1119,7 +1119,7 @@ export default function (self) {
         end = Math.min(end, g);
         for (o = start; o < end; o += 1) {
           i = self.orders.columns[o];
-          header = s[i];
+          header = schema[i];
           if (!header.hidden) {
             d = {
               title: header.title,
@@ -1185,7 +1185,7 @@ export default function (self) {
             isColumnHeaderCell: true,
             isColumnHeaderCellCap: true,
             type: 'string',
-            index: s.length,
+            index: schema.length,
           };
           drawCell({ endCap: '' }, -1, -1)(c, -1, -1);
         }
@@ -1205,11 +1205,11 @@ export default function (self) {
       }
     }
     function drawRow(rowOrderIndex, rowIndex) {
-      var i,
+      var headerIndex,
         treeHeight,
         rowSansTreeHeight,
-        o,
-        g = s.length;
+        columnOrderIndex,
+        g = schema.length;
       if (y - cellHeight * 2 > h) {
         return false;
       }
@@ -1227,11 +1227,19 @@ export default function (self) {
       }
       cellHeight = rowHeight;
       //draw normal columns
-      for (o = self.scrollIndexLeft; o < g; o += 1) {
-        i = self.orders.columns[o];
-        x += drawCell(rowData, rowOrderIndex, rowIndex)(s[i], i, o);
+      for (
+        columnOrderIndex = self.scrollIndexLeft;
+        columnOrderIndex < g;
+        columnOrderIndex += 1
+      ) {
+        headerIndex = self.orders.columns[columnOrderIndex];
+        x += drawCell(rowData, rowOrderIndex, rowIndex)(
+          schema[headerIndex],
+          headerIndex,
+          columnOrderIndex,
+        );
         if (x > self.width) {
-          self.scrollIndexRight = o;
+          self.scrollIndexRight = columnOrderIndex;
           self.scrollPixelRight = x;
           break;
         }
@@ -1241,9 +1249,17 @@ export default function (self) {
       if (self.attributes.showRowHeaders) {
         x += rowHeaderCellWidth;
       }
-      for (o = 0; o < self.frozenColumn; o += 1) {
-        i = self.orders.columns[o];
-        x += drawCell(rowData, rowOrderIndex, rowIndex)(s[i], i, o);
+      for (
+        columnOrderIndex = 0;
+        columnOrderIndex < self.frozenColumn;
+        columnOrderIndex += 1
+      ) {
+        headerIndex = self.orders.columns[columnOrderIndex];
+        x += drawCell(rowData, rowOrderIndex, rowIndex)(
+          schema[headerIndex],
+          headerIndex,
+          columnOrderIndex,
+        );
         if (x > self.width) {
           break;
         }
@@ -1295,7 +1311,7 @@ export default function (self) {
     }
     function initDraw() {
       self.visibleRows = [];
-      s = self.getSchema();
+      schema = self.getSchema();
       self.visibleCells = [];
       self.canvasOffsetTop = self.isChildGrid ? self.parentNode.offsetTop : 0.5;
       self.canvasOffsetLeft = self.isChildGrid
@@ -1349,7 +1365,7 @@ export default function (self) {
       var o,
         rowOrderIndex,
         i,
-        g = s.length;
+        g = schema.length;
       x =
         -self.scrollBox.scrollLeft +
         self.scrollPixelLeft +
@@ -1381,7 +1397,7 @@ export default function (self) {
         for (o = self.scrollIndexLeft; o < g; o += 1) {
           i = self.orders.columns[o];
           x += drawCell(self.newRow, viewData.length, viewData.length)(
-            s[i],
+            schema[i],
             i,
             o,
           );
@@ -1467,7 +1483,7 @@ export default function (self) {
           self.currentCell.sortColumnIndex !==
             self.reorderObject.sortColumnIndex &&
           self.currentCell.sortColumnIndex > -1 &&
-          self.currentCell.sortColumnIndex < s.length
+          self.currentCell.sortColumnIndex < schema.length
         ) {
           addBorderLine(
             m,

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1347,7 +1347,7 @@ export default function (self) {
         self.ctx.clip();
       }
       var o,
-        n,
+        rowOrderIndex,
         i,
         g = s.length;
       x =
@@ -1365,10 +1365,10 @@ export default function (self) {
         rowIndex < l;
         rowIndex += 1
       ) {
-        n = self.orders.rows[rowIndex];
+        rowOrderIndex = self.orders.rows[rowIndex];
         self.scrollIndexBottom = rowIndex;
         self.scrollPixelBottom = y;
-        if (!drawRow(n, rowIndex)) {
+        if (!drawRow(rowOrderIndex, rowIndex)) {
           break;
         }
       }

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -901,9 +901,11 @@ export default function (self) {
           columnIndex: columnOrderIndex,
           rowIndex: rowOrderIndex,
 
-          // TODO: set correct value
-          viewRowIndex: null,
-          viewColumnIndex: null,
+          viewRowIndex: rowOrderIndex,
+          viewColumnIndex: columnOrderIndex,
+
+          boundRowIndex: self.getBoundRowIndexFromViewRowIndex(rowOrderIndex),
+          boundColumnIndex: columnOrderIndex,
 
           sortColumnIndex: headerIndex,
           sortRowIndex: rowIndex,

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -572,13 +572,13 @@ export default function (self) {
       r,
       rd,
       aCell,
-      data = self.viewData || [],
+      viewData = self.viewData || [],
       bc = self.style.gridBorderCollapse === 'collapse',
       selectionBorders = [],
       moveBorders = [],
       selectionHandles = [],
       rowHeaders = [],
-      l = data.length,
+      l = viewData.length,
       u = self.currentCell || {},
       columnHeaderCellHeight = self.getColumnHeaderCellHeight(),
       rowHeaderCellWidth = self.getRowHeaderCellWidth(),
@@ -587,7 +587,7 @@ export default function (self) {
     p = performance.now();
     self.visibleRowHeights = [];
     // if data length has changed, there is no way to know
-    if (data.length > self.orders.rows.length) {
+    if (viewData.length > self.orders.rows.length) {
       self.createRowOrders();
     }
     function drawScrollBars() {
@@ -1210,7 +1210,7 @@ export default function (self) {
       if (y - cellHeight * 2 > h) {
         return false;
       }
-      rd = data[r];
+      rd = viewData[r];
       rowOpen = self.openChildren[r];
       rowSansTreeHeight =
         (self.sizes.rows[r] || self.style.cellHeight) * self.scale;
@@ -1254,7 +1254,7 @@ export default function (self) {
         self.style.cellBorderWidth;
       // don't draw a tree for the new row
       treeGrid = self.childGrids[r];
-      if (r !== data.length && rowOpen) {
+      if (r !== viewData.length && rowOpen) {
         treeGrid.visible = true;
         treeGrid.parentNode = {
           offsetTop: y + rowSansTreeHeight + self.canvasOffsetTop,
@@ -1309,7 +1309,7 @@ export default function (self) {
     }
     function drawFrozenRows() {
       var n,
-        ln = Math.min(data.length, self.frozenRow);
+        ln = Math.min(viewData.length, self.frozenRow);
       x =
         -self.scrollBox.scrollLeft +
         self.scrollPixelLeft +
@@ -1373,12 +1373,22 @@ export default function (self) {
         rowOpen = false;
         for (o = self.scrollIndexLeft; o < g; o += 1) {
           i = self.orders.columns[o];
-          x += drawCell(self.newRow, data.length, data.length)(s[i], i, o);
+          x += drawCell(self.newRow, viewData.length, viewData.length)(
+            s[i],
+            i,
+            o,
+          );
           if (x > self.width + self.scrollBox.scrollLeft) {
             break;
           }
         }
-        rowHeaders.push([self.newRow, data.length, data.length, y, rowHeight]);
+        rowHeaders.push([
+          self.newRow,
+          viewData.length,
+          viewData.length,
+          y,
+          rowHeight,
+        ]);
       }
       self.ctx.restore();
     }

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1098,14 +1098,21 @@ export default function (self) {
     function drawRowHeader(rowData, rowIndex, rowOrderIndex) {
       if (self.attributes.showRowHeaders) {
         x = 0;
-        const i = rowIndex + 1;
-        const rowHeaderCell = { rowHeaderCell: i };
+
+        // When filtering we'd like to display the actual row numbers,
+        // as it is in the unfiltered data, instead of simply the viewed
+        // row index + 1:
+        const rowHeaderValue = self.hasActiveFilters()
+          ? self.getBoundRowIndexFromViewRowIndex(rowIndex) + 1
+          : rowIndex + 1;
+
+        const rowHeaderCell = { rowHeaderCell: rowHeaderValue };
         const headerDescription = {
           name: 'rowHeaderCell',
           width: self.sizes.columns[-1] || self.style.rowHeaderCellWidth,
           style: 'rowHeaderCell',
           type: 'string',
-          data: i,
+          data: rowHeaderValue,
           index: -1,
         };
         rowOpen = self.openChildren[rowIndex];

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -569,7 +569,7 @@ export default function (self) {
       h,
       w,
       s,
-      r,
+      rowIndex,
       rd,
       aCell,
       viewData = self.viewData || [],
@@ -1201,7 +1201,7 @@ export default function (self) {
         }
       }
     }
-    function drawRow(r, d) {
+    function drawRow(r, rowIndex) {
       var i,
         treeHeight,
         rowSansTreeHeight,
@@ -1226,7 +1226,7 @@ export default function (self) {
       //draw normal columns
       for (o = self.scrollIndexLeft; o < g; o += 1) {
         i = self.orders.columns[o];
-        x += drawCell(rd, r, d)(s[i], i, o);
+        x += drawCell(rd, r, rowIndex)(s[i], i, o);
         if (x > self.width) {
           self.scrollIndexRight = o;
           self.scrollPixelRight = x;
@@ -1240,7 +1240,7 @@ export default function (self) {
       }
       for (o = 0; o < self.frozenColumn; o += 1) {
         i = self.orders.columns[o];
-        x += drawCell(rd, r, d)(s[i], i, o);
+        x += drawCell(rd, r, rowIndex)(s[i], i, o);
         if (x > self.width) {
           break;
         }
@@ -1285,7 +1285,7 @@ export default function (self) {
         treeGrid.parentNode.offsetHeight = 0;
         delete self.sizes.trees[r];
       }
-      rowHeaders.push([rd, r, d, y, rowHeight]);
+      rowHeaders.push([rd, r, rowIndex, y, rowHeight]);
       self.visibleRowHeights[r] = rowHeight;
       y += cellHeight + (bc ? 0 : self.style.cellBorderWidth);
       return true;
@@ -1315,9 +1315,9 @@ export default function (self) {
         self.scrollPixelLeft +
         self.style.cellBorderWidth;
       y = columnHeaderCellHeight;
-      for (r = 0; r < ln; r += 1) {
-        n = self.orders.rows[r];
-        if (!drawRow(n, r)) {
+      for (rowIndex = 0; rowIndex < ln; rowIndex += 1) {
+        n = self.orders.rows[rowIndex];
+        if (!drawRow(n, rowIndex)) {
           break;
         }
       }
@@ -1357,11 +1357,15 @@ export default function (self) {
           self.scrollPixelTop +
           self.style.cellBorderWidth;
       }
-      for (r = self.frozenRow + self.scrollIndexTop; r < l; r += 1) {
-        n = self.orders.rows[r];
-        self.scrollIndexBottom = r;
+      for (
+        rowIndex = self.frozenRow + self.scrollIndexTop;
+        rowIndex < l;
+        rowIndex += 1
+      ) {
+        n = self.orders.rows[rowIndex];
+        self.scrollIndexBottom = rowIndex;
         self.scrollPixelBottom = y;
-        if (!drawRow(n, r)) {
+        if (!drawRow(n, rowIndex)) {
           break;
         }
       }

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1087,12 +1087,11 @@ export default function (self) {
       };
     }
     function drawRowHeader(rowData, index, rowOrderIndex) {
-      var a, i;
       if (self.attributes.showRowHeaders) {
         x = 0;
-        i = index + 1;
-        rowHeaderCell = { rowHeaderCell: i };
-        a = {
+        const i = index + 1;
+        const rowHeaderCell = { rowHeaderCell: i };
+        const headerDescription = {
           name: 'rowHeaderCell',
           width: self.sizes.columns[-1] || self.style.rowHeaderCellWidth,
           style: 'rowHeaderCell',
@@ -1101,7 +1100,11 @@ export default function (self) {
           index: -1,
         };
         rowOpen = self.openChildren[index];
-        drawCell(rowHeaderCell, index, rowOrderIndex)(a, -1, -1);
+        drawCell(rowHeaderCell, index, rowOrderIndex)(
+          headerDescription,
+          -1,
+          -1,
+        );
       }
     }
     function drawHeaders() {

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1362,7 +1362,7 @@ export default function (self) {
         );
         self.ctx.clip();
       }
-      var o,
+      var columnOrderIndex,
         rowOrderIndex,
         headerIndex,
         g = schema.length;
@@ -1394,12 +1394,16 @@ export default function (self) {
         }
         rowHeight = cellHeight = self.style.cellHeight;
         rowOpen = false;
-        for (o = self.scrollIndexLeft; o < g; o += 1) {
-          headerIndex = self.orders.columns[o];
+        for (
+          columnOrderIndex = self.scrollIndexLeft;
+          columnOrderIndex < g;
+          columnOrderIndex += 1
+        ) {
+          headerIndex = self.orders.columns[columnOrderIndex];
           x += drawCell(self.newRow, viewData.length, viewData.length)(
             schema[headerIndex],
             headerIndex,
-            o,
+            columnOrderIndex,
           );
           if (x > self.width + self.scrollBox.scrollLeft) {
             break;

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1364,7 +1364,7 @@ export default function (self) {
       }
       var o,
         rowOrderIndex,
-        i,
+        headerIndex,
         g = schema.length;
       x =
         -self.scrollBox.scrollLeft +
@@ -1395,10 +1395,10 @@ export default function (self) {
         rowHeight = cellHeight = self.style.cellHeight;
         rowOpen = false;
         for (o = self.scrollIndexLeft; o < g; o += 1) {
-          i = self.orders.columns[o];
+          headerIndex = self.orders.columns[o];
           x += drawCell(self.newRow, viewData.length, viewData.length)(
-            schema[i],
-            i,
+            schema[headerIndex],
+            headerIndex,
             o,
           );
           if (x > self.width + self.scrollBox.scrollLeft) {

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -572,7 +572,7 @@ export default function (self) {
       r,
       rd,
       aCell,
-      data = self.data || [],
+      data = self.viewData || [],
       bc = self.style.gridBorderCollapse === 'collapse',
       selectionBorders = [],
       moveBorders = [],

--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1327,7 +1327,7 @@ export default function (self) {
       fillRect(0, 0, w, h);
     }
     function drawFrozenRows() {
-      var n,
+      var rowOrderIndex,
         ln = Math.min(viewData.length, self.frozenRow);
       x =
         -self.scrollBox.scrollLeft +
@@ -1335,8 +1335,8 @@ export default function (self) {
         self.style.cellBorderWidth;
       y = columnHeaderCellHeight;
       for (rowIndex = 0; rowIndex < ln; rowIndex += 1) {
-        n = self.orders.rows[rowIndex];
-        if (!drawRow(n, rowIndex)) {
+        rowOrderIndex = self.orders.rows[rowIndex];
+        if (!drawRow(rowOrderIndex, rowIndex)) {
           break;
         }
       }

--- a/lib/events.js
+++ b/lib/events.js
@@ -126,6 +126,7 @@ export default function (self) {
       dataHeight = 0,
       dataWidth = 0,
       dims,
+      // TODO:
       l = (self.data || []).length,
       columnHeaderCellHeight = self.getColumnHeaderCellHeight(),
       rowHeaderCellWidth = self.getRowHeaderCellWidth(),
@@ -345,6 +346,7 @@ export default function (self) {
   };
   self.scroll = function (dontDraw) {
     var s = self.getSchema(),
+      // TODO:
       l = (self.data || []).length,
       ch = self.style.cellHeight;
     // go too far in leaps, then get focused
@@ -362,6 +364,7 @@ export default function (self) {
     self.scrollPixelLeft = 0;
     while (
       self.scrollPixelTop < self.scrollBox.scrollTop &&
+      // TODO:
       self.scrollIndexTop < self.data.length
     ) {
       // start on index +1 since index 0 was used in "go too far" section above
@@ -381,10 +384,12 @@ export default function (self) {
         self.orders.columns[self.scrollIndexLeft],
       );
     }
+    // TODO:
     if ((self.data || []).length > 0) {
       self.scrollIndexTop = Math.max(self.scrollIndexTop - 1, 0);
       self.scrollPixelTop = Math.max(
         self.scrollPixelTop -
+          // TODO:
           (self.data[self.scrollIndexTop]
             ? (self.sizes.rows[self.scrollIndexTop] || ch) +
               (self.sizes.trees[self.scrollIndexTop] || 0)
@@ -890,6 +895,7 @@ export default function (self) {
         self.reorderTarget.sortColumnIndex < self.getSchema().length) ||
         (self.dragMode === 'row-reorder' &&
           self.reorderTarget.rowIndex > -1 &&
+          // TODO:
           self.reorderTarget.rowIndex < self.data.length)) &&
       self.reorderObject[i] !== self.reorderTarget[i] &&
       !self.dispatchEvent('reorder', {
@@ -1208,6 +1214,7 @@ export default function (self) {
       x = self.activeCell.columnIndex,
       y = self.activeCell.rowIndex,
       ctrl = e.ctrlKey || e.metaKey,
+      // TODO:
       last = self.data.length - 1,
       s = self.getSchema(),
       cols = s.length - 1;
@@ -1265,6 +1272,7 @@ export default function (self) {
     } else if (e.key === 'Home' || (ctrl && e.key === 'ArrowUp')) {
       y = 0;
     } else if (e.key === 'End' || (ctrl && e.key === 'ArrowDown')) {
+      // TODO:
       y = self.data.length - 1;
     } else if (ctrl && e.key === 'ArrowRight') {
       x = adjacentCells.last;
@@ -1500,6 +1508,7 @@ export default function (self) {
         var realRowIndex = self.orders.rows[startRowIndex + rowIndex];
         var cells = rows[rowIndex];
 
+        // TODO:
         var existingRowData = self.data[realRowIndex];
         var newRowData = Object.assign({}, existingRowData);
 
@@ -1526,6 +1535,7 @@ export default function (self) {
           newRowData[columnName] = cellData;
         }
 
+        // TODO:
         self.data[realRowIndex] = newRowData;
       }
       self.selections = selections;

--- a/lib/events.js
+++ b/lib/events.js
@@ -127,7 +127,7 @@ export default function (self) {
       dataWidth = 0,
       dims,
       // TODO:
-      l = (self.data || []).length,
+      l = (self.viewData || []).length,
       columnHeaderCellHeight = self.getColumnHeaderCellHeight(),
       rowHeaderCellWidth = self.getRowHeaderCellWidth(),
       ch = self.style.cellHeight,

--- a/lib/events.js
+++ b/lib/events.js
@@ -1636,7 +1636,6 @@ export default function (self) {
     }
     var t,
       d,
-      data = self.data || [],
       tableRows = [],
       textRows = [],
       outputHeaders = {},

--- a/lib/events.js
+++ b/lib/events.js
@@ -126,7 +126,6 @@ export default function (self) {
       dataHeight = 0,
       dataWidth = 0,
       dims,
-      // TODO:
       l = (self.viewData || []).length,
       columnHeaderCellHeight = self.getColumnHeaderCellHeight(),
       rowHeaderCellWidth = self.getRowHeaderCellWidth(),
@@ -891,8 +890,7 @@ export default function (self) {
         self.reorderTarget.sortColumnIndex < self.getSchema().length) ||
         (self.dragMode === 'row-reorder' &&
           self.reorderTarget.rowIndex > -1 &&
-          // TODO:
-          self.reorderTarget.rowIndex < self.data.length)) &&
+          self.reorderTarget.rowIndex < self.viewData.length)) &&
       self.reorderObject[i] !== self.reorderTarget[i] &&
       !self.dispatchEvent('reorder', {
         NativeEvent: e,
@@ -1210,8 +1208,7 @@ export default function (self) {
       x = self.activeCell.columnIndex,
       y = self.activeCell.rowIndex,
       ctrl = e.ctrlKey || e.metaKey,
-      // TODO:
-      last = self.data.length - 1,
+      last = self.viewData.length - 1,
       s = self.getSchema(),
       cols = s.length - 1;
 
@@ -1268,8 +1265,7 @@ export default function (self) {
     } else if (e.key === 'Home' || (ctrl && e.key === 'ArrowUp')) {
       y = 0;
     } else if (e.key === 'End' || (ctrl && e.key === 'ArrowDown')) {
-      // TODO:
-      y = self.data.length - 1;
+      y = self.viewData.length - 1;
     } else if (ctrl && e.key === 'ArrowRight') {
       x = adjacentCells.last;
     } else if (ctrl && e.key === 'ArrowLeft') {
@@ -1504,8 +1500,7 @@ export default function (self) {
         var realRowIndex = self.orders.rows[startRowIndex + rowIndex];
         var cells = rows[rowIndex];
 
-        // TODO:
-        var existingRowData = self.data[realRowIndex];
+        var existingRowData = self.viewData[realRowIndex];
         var newRowData = Object.assign({}, existingRowData);
 
         selections[realRowIndex] = [];
@@ -1532,7 +1527,8 @@ export default function (self) {
         }
 
         // TODO:
-        self.data[realRowIndex] = newRowData;
+        // FIXME: this should update originalData as well
+        self.viewData[realRowIndex] = newRowData;
       }
       self.selections = selections;
     }

--- a/lib/events.js
+++ b/lib/events.js
@@ -346,8 +346,7 @@ export default function (self) {
   };
   self.scroll = function (dontDraw) {
     var s = self.getSchema(),
-      // TODO:
-      l = (self.data || []).length,
+      l = (self.viewData || []).length,
       ch = self.style.cellHeight;
     // go too far in leaps, then get focused
     self.scrollIndexTop = Math.floor(
@@ -364,8 +363,7 @@ export default function (self) {
     self.scrollPixelLeft = 0;
     while (
       self.scrollPixelTop < self.scrollBox.scrollTop &&
-      // TODO:
-      self.scrollIndexTop < self.data.length
+      self.scrollIndexTop < self.viewData.length
     ) {
       // start on index +1 since index 0 was used in "go too far" section above
       self.scrollIndexTop += 1;
@@ -384,13 +382,11 @@ export default function (self) {
         self.orders.columns[self.scrollIndexLeft],
       );
     }
-    // TODO:
-    if ((self.data || []).length > 0) {
+    if ((self.viewData || []).length > 0) {
       self.scrollIndexTop = Math.max(self.scrollIndexTop - 1, 0);
       self.scrollPixelTop = Math.max(
         self.scrollPixelTop -
-          // TODO:
-          (self.data[self.scrollIndexTop]
+          (self.viewData[self.scrollIndexTop]
             ? (self.sizes.rows[self.scrollIndexTop] || ch) +
               (self.sizes.trees[self.scrollIndexTop] || 0)
             : ch) *

--- a/lib/events.js
+++ b/lib/events.js
@@ -1528,7 +1528,7 @@ export default function (self) {
 
         // TODO:
         // FIXME: this should update originalData as well
-        self.viewData[realRowIndex] = newRowData;
+        self.originalData[realRowIndex] = newRowData;
       }
       self.selections = selections;
     }
@@ -1547,6 +1547,10 @@ export default function (self) {
     self.dispatchEvent('afterpaste', {
       cells: affectedCells,
     });
+
+    // Because originalData has been updated, we must refresh
+    // viewData to ensure the new cell values are rendered
+    self.refresh();
 
     return rows.length;
   };

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1337,7 +1337,7 @@ export default function (self, ctor) {
       // apply filter, sort, etc to incoming dataset, set viewData:
       self.refresh();
       // empty data was set
-      if (!self.schema && (self.data || []).length === 0) {
+      if (!self.schema && (self.originalData || []).length === 0) {
         self.tempSchema = [{ name: '' }];
       }
       self.fitColumnToValues('cornerCell', true);

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -37,6 +37,10 @@ export default function (self, ctor) {
       });
     },
     sort: function () {
+      console.warn(
+        'grid.orderings.sort has been deprecated. Please use grid.refresh().',
+      );
+
       self.orderings.columns.forEach(function (col) {
         self.viewData.sort(col.sortFunction(col.orderBy, col.orderDirection));
       });
@@ -184,11 +188,11 @@ export default function (self, ctor) {
     return selectedData;
   };
   self.getBoundRowIndexFromViewRowIndex = function (viewRowIndex) {
-    if (self.boundRowIndexMap) {
-      return self.boundRowIndexMap[viewRowIndex];
+    if (self.boundRowIndexMap && self.boundRowIndexMap.has(viewRowIndex)) {
+      return self.boundRowIndexMap.get(viewRowIndex);
     }
 
-    return -1;
+    return undefined;
   };
   self.getColumnHeaderCellHeight = function () {
     if (!self.attributes.showColumnHeaders) {
@@ -286,29 +290,64 @@ export default function (self, ctor) {
     }
     return f;
   };
-  self.applyFilters = function () {
-    Object.keys(self.columnFilters).forEach(function (filter) {
-      var header = self.getHeaderByName(filter);
+  self.getFilteredAndSortedViewData = function (originalData) {
+    // We make a copy of originalData here in order be able to
+    // filter and sort rows without modifying the original array.
+    // Each row is turned into a (row, rowIndex) tuple
+    // so that when we apply filters, we can refer back to the
+    // row's original row number in originalData. This becomes
+    // useful when emitting cell events.
+    let newViewData = originalData.map((row, originalRowIndex) => [
+      row,
+      originalRowIndex,
+    ]);
+
+    // Apply filtering
+    for (const [headerName, filterText] of Object.entries(self.columnFilters)) {
+      const header = self.getHeaderByName(headerName);
+
       if (!header) {
-        return;
+        continue;
       }
-      self.currentFilter =
+
+      const currentFilterFunction =
         header.filter || self.filter(header.type || 'string');
-      self.viewData = self.viewData.filter(function (row) {
-        return self.currentFilter(row[filter], self.columnFilters[filter]);
+
+      newViewData = newViewData.filter(function ([row]) {
+        const cellValue = row[headerName];
+        const shouldIncludeRow = currentFilterFunction(cellValue, filterText);
+
+        return shouldIncludeRow;
       });
-    });
-    self.resize();
-    self.draw(true);
+    }
+
+    // Apply sorting
+    for (const column of self.orderings.columns) {
+      const sortFn = column.sortFunction(column.orderBy, column.orderDirection);
+
+      newViewData.sort(([rowA], [rowB]) => sortFn(rowA, rowB));
+    }
+
+    return {
+      viewData: newViewData.map(([row]) => row),
+      boundRowIndexMap: new Map(
+        newViewData.map(([_row, originalRowIndex], viewRowIndex) => [
+          viewRowIndex,
+          originalRowIndex,
+        ]),
+      ),
+    };
   };
   self.refresh = function () {
-    // We make a copy of originalData here in order be able
-    // to sort or filter rows without modifying the original
-    // array.
-    self.viewData = Array.from(self.originalData);
+    const { viewData, boundRowIndexMap } = self.getFilteredAndSortedViewData(
+      self.originalData,
+    );
 
-    self.applyFilters();
-    self.orderings.sort();
+    self.viewData = viewData;
+    self.boundRowIndexMap = boundRowIndexMap;
+
+    self.resize();
+    self.draw(true);
   };
   self.getBestGuessDataType = function (columnName, data) {
     var t,

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -268,7 +268,6 @@ export default function (self, ctor) {
     return f;
   };
   self.applyFilters = function () {
-    self.refreshFromOrigialData();
     Object.keys(self.columnFilters).forEach(function (filter) {
       var header = self.getHeaderByName(filter);
       if (!header) {
@@ -284,6 +283,10 @@ export default function (self, ctor) {
     self.draw(true);
   };
   self.refresh = function () {
+    self.data = self.intf.boundData.filter(function (row) {
+      return true;
+    });
+
     self.applyFilters();
     self.orderings.sort();
   };
@@ -358,11 +361,6 @@ export default function (self, ctor) {
         e,
       );
     }
-  };
-  self.refreshFromOrigialData = function () {
-    self.data = self.originalData.filter(function (row) {
-      return true;
-    });
   };
   self.validateColumn = function (c, s) {
     if (!c.name) {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -240,7 +240,7 @@ export default function (self, ctor) {
     self.orders.columns = fillArray(0, s.length - 1);
   };
   self.createRowOrders = function () {
-    self.orders.rows = fillArray(0, self.viewData.length - 1);
+    self.orders.rows = fillArray(0, self.originalData.length - 1);
   };
   self.getVisibleSchema = function () {
     return self.getSchema().filter(function (col) {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1157,7 +1157,7 @@ export default function (self, ctor) {
       if (!Array.isArray(val)) {
         throw new TypeError('Value must be an array.');
       }
-      if (!self.data || val.length < self.data.length) {
+      if (!self.originalData || val.length < self.originalData.length) {
         throw new RangeError(
           'Array length must be equal to or greater than number of rows.',
         );

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -267,7 +267,7 @@ export default function (self, ctor) {
     }
     return f;
   };
-  self.applyFilter = function () {
+  self.applyFilters = function () {
     self.refreshFromOrigialData();
     Object.keys(self.columnFilters).forEach(function (filter) {
       var header = self.getHeaderByName(filter);
@@ -284,7 +284,7 @@ export default function (self, ctor) {
     self.draw(true);
   };
   self.applyDataTransforms = function () {
-    self.applyFilter();
+    self.applyFilters();
     self.orderings.sort();
   };
   self.getBestGuessDataType = function (columnName, data) {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -183,6 +183,13 @@ export default function (self, ctor) {
 
     return selectedData;
   };
+  self.getBoundRowIndex = function (viewRowIndex) {
+    if (self.boundRowIndexMap) {
+      return self.boundRowIndexMap[viewRowIndex];
+    }
+
+    return -1;
+  };
   self.getColumnHeaderCellHeight = function () {
     if (!self.attributes.showColumnHeaders) {
       return 0;

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -290,6 +290,9 @@ export default function (self, ctor) {
     }
     return f;
   };
+  self.hasActiveFilters = function () {
+    return self.columnFilters && Object.keys(self.columnFilters).length > 0;
+  };
   self.getFilteredAndSortedViewData = function (originalData) {
     // We make a copy of originalData here in order be able to
     // filter and sort rows without modifying the original array.
@@ -703,6 +706,7 @@ export default function (self, ctor) {
     self.intf.isColumnVisible = self.isColumnVisible;
     self.intf.order = self.order;
     self.intf.draw = self.draw;
+    self.intf.refresh = self.refresh;
     self.intf.isComponent = self.isComponent;
     self.intf.selectArea = self.selectArea;
     self.intf.clipElement = self.clipElement;
@@ -792,6 +796,18 @@ export default function (self, ctor) {
     Object.defineProperty(self.intf, 'hasFocus', {
       get: function () {
         return self.hasFocus;
+      },
+    });
+    /**
+     * Indicates whether grid has filters active
+     * @memberof canvasDatagrid
+     * @name hasActiveFilters
+     * @property
+     * @returns {boolean} When true, grid data is being filtered
+     */
+    Object.defineProperty(self.intf, 'hasActiveFilters', {
+      get: function () {
+        return self.hasActiveFilters();
       },
     });
     Object.defineProperty(self.intf, 'style', {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -283,7 +283,7 @@ export default function (self, ctor) {
     self.resize();
     self.draw(true);
   };
-  self.applyDataTransforms = function () {
+  self.refresh = function () {
     self.applyFilters();
     self.orderings.sort();
   };
@@ -1326,7 +1326,7 @@ export default function (self, ctor) {
       // set the unfiltered/sorted data array
       self.originalData = data;
       // apply filter, sort, etc to incoming dataset
-      self.applyDataTransforms();
+      self.refresh();
       // empty data was set
       if (!self.schema && (self.data || []).length === 0) {
         self.tempSchema = [{ name: '' }];

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1342,6 +1342,11 @@ export default function (self, ctor) {
       callback();
     });
   };
+  Object.defineProperty(self.intf, 'viewData', {
+    get: function () {
+      return self.data;
+    },
+  });
   Object.defineProperty(self.intf, 'boundData', {
     get: function () {
       return self.originalData;

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -38,7 +38,7 @@ export default function (self, ctor) {
     },
     sort: function () {
       self.orderings.columns.forEach(function (col) {
-        self.data.sort(col.sortFunction(col.orderBy, col.orderDirection));
+        self.viewData.sort(col.sortFunction(col.orderBy, col.orderDirection));
       });
     },
   };
@@ -228,7 +228,7 @@ export default function (self, ctor) {
     self.orders.columns = fillArray(0, s.length - 1);
   };
   self.createRowOrders = function () {
-    self.orders.rows = fillArray(0, self.data.length - 1);
+    self.orders.rows = fillArray(0, self.viewData.length - 1);
   };
   self.getVisibleSchema = function () {
     return self.getSchema().filter(function (col) {
@@ -275,7 +275,7 @@ export default function (self, ctor) {
       }
       self.currentFilter =
         header.filter || self.filter(header.type || 'string');
-      self.data = self.data.filter(function (row) {
+      self.viewData = self.viewData.filter(function (row) {
         return self.currentFilter(row[filter], self.columnFilters[filter]);
       });
     });
@@ -283,9 +283,10 @@ export default function (self, ctor) {
     self.draw(true);
   };
   self.refresh = function () {
-    self.data = self.intf.boundData.filter(function (row) {
-      return true;
-    });
+    self.viewData = Array.from(self.originalData);
+
+    // TODO: needed to keep tests passing
+    self.data = Array.from(self.originalData);
 
     self.applyFilters();
     self.orderings.sort();
@@ -1308,6 +1309,10 @@ export default function (self, ctor) {
       throw new Error('Unsupported data type.');
     }
     self.intf.parsers[self.dataType](data, function (data, schema) {
+      // set the unfiltered/sorted data array
+      self.originalData = data;
+      self.viewData = Array.from(self.originalData);
+
       if (Array.isArray(schema)) {
         self.schema = schema;
       }
@@ -1321,9 +1326,7 @@ export default function (self, ctor) {
       if (self.getSchema()) {
         self.createColumnOrders();
       }
-      // set the unfiltered/sorted data array
-      self.originalData = data;
-      // apply filter, sort, etc to incoming dataset
+      // apply filter, sort, etc to incoming dataset, set viewData:
       self.refresh();
       // empty data was set
       if (!self.schema && (self.data || []).length === 0) {
@@ -1342,7 +1345,7 @@ export default function (self, ctor) {
   };
   Object.defineProperty(self.intf, 'viewData', {
     get: function () {
-      return self.data;
+      return self.viewData;
     },
   });
   Object.defineProperty(self.intf, 'boundData', {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -183,7 +183,7 @@ export default function (self, ctor) {
 
     return selectedData;
   };
-  self.getBoundRowIndex = function (viewRowIndex) {
+  self.getBoundRowIndexFromViewRowIndex = function (viewRowIndex) {
     if (self.boundRowIndexMap) {
       return self.boundRowIndexMap[viewRowIndex];
     }

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -296,6 +296,9 @@ export default function (self, ctor) {
   };
   self.refresh = function () {
     self.viewData = Array.from(self.originalData);
+
+    self.data = [];
+
     self.applyFilters();
     self.orderings.sort();
   };
@@ -446,7 +449,9 @@ export default function (self, ctor) {
       typeof self.storedSettings.orders === 'object' &&
       self.storedSettings.orders !== null
     ) {
-      if (self.storedSettings.orders.rows.length >= (self.data || []).length) {
+      if (
+        self.storedSettings.orders.rows.length >= (self.viewData || []).length
+      ) {
         self.orders.rows = self.storedSettings.orders.rows;
       }
       s = self.getSchema();
@@ -1363,7 +1368,7 @@ export default function (self, ctor) {
   });
   Object.defineProperty(self.intf, 'data', {
     get: function dataGetter() {
-      return self.data;
+      return self.originalData;
     },
     set: function dataSetter(value) {
       self.etl(value, function () {
@@ -1371,7 +1376,7 @@ export default function (self, ctor) {
         self.createNewRowData();
         if (
           self.attributes.autoResizeColumns &&
-          self.data.length > 0 &&
+          self.originalData.length > 0 &&
           self.storedSettings === undefined
         ) {
           self.autosize();
@@ -1380,7 +1385,7 @@ export default function (self, ctor) {
         self.fitColumnToValues('cornerCell', true);
         self.createRowOrders();
         self.tryLoadStoredSettings();
-        self.dispatchEvent('datachanged', { data: self.data });
+        self.dispatchEvent('datachanged', { data: self.originalData });
         self.resize(true);
       });
     },

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1342,6 +1342,11 @@ export default function (self, ctor) {
       callback();
     });
   };
+  Object.defineProperty(self.intf, 'boundData', {
+    get: function () {
+      return self.originalData;
+    },
+  });
   Object.defineProperty(self.intf, 'data', {
     get: function dataGetter() {
       return self.data;

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -284,10 +284,6 @@ export default function (self, ctor) {
   };
   self.refresh = function () {
     self.viewData = Array.from(self.originalData);
-
-    // TODO: needed to keep tests passing
-    self.data = Array.from(self.originalData);
-
     self.applyFilters();
     self.orderings.sort();
   };

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -136,40 +136,52 @@ export default function (self, ctor) {
   ];
   self.mouse = { x: 0, y: 0 };
   self.getSelectedData = function (expandToRow) {
-    var d = [],
-      s = self.getSchema(),
-      l = self.data.length;
-    if (l === 0) {
+    const selectedData = [];
+    const schema = self.getSchema();
+    const viewDataLength = self.viewData.length;
+
+    if (viewDataLength === 0) {
       return [];
     }
-    self.selections.forEach(function (row, index) {
+
+    // self.selections is a sparse array, so `index` here
+    // will equal the row index as where it's rendered,
+    // not as where it is in the original data array.
+    self.selections.forEach(function (row, viewRowIndex) {
       if (!row) {
         return;
       }
-      if (index === l) {
+
+      if (viewRowIndex === viewDataLength) {
         return;
       }
+
       if (row.length === 0) {
-        d[index] = null;
+        selectedData[viewRowIndex] = null;
         return;
       }
-      d[index] = {};
+
+      selectedData[viewRowIndex] = {};
+
       row.forEach(function (col) {
-        var orderedIndex;
-        if (col === -1 || !s[col]) {
+        if (col === -1 || !schema[col]) {
           return;
         }
-        orderedIndex = self.orders.columns[col];
-        if (!expandToRow && s[orderedIndex].hidden) {
+
+        const orderedIndex = self.orders.columns[col];
+
+        if (!expandToRow && schema[orderedIndex].hidden) {
           return;
         }
-        if (self.data[index]) {
-          d[index][s[orderedIndex].name] =
-            self.data[index][s[orderedIndex].name];
+
+        if (self.viewData[viewRowIndex]) {
+          selectedData[viewRowIndex][schema[orderedIndex].name] =
+            self.viewData[viewRowIndex][schema[orderedIndex].name];
         }
       });
     });
-    return d;
+
+    return selectedData;
   };
   self.getColumnHeaderCellHeight = function () {
     if (!self.attributes.showColumnHeaders) {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -144,7 +144,7 @@ export default function (self, ctor) {
       return [];
     }
 
-    // self.selections is a sparse array, so `index` here
+    // self.selections is a sparse array, so `viewRowIndex` here
     // will equal the row index as where it's rendered,
     // not as where it is in the original data array.
     self.selections.forEach(function (row, viewRowIndex) {
@@ -295,9 +295,10 @@ export default function (self, ctor) {
     self.draw(true);
   };
   self.refresh = function () {
+    // We make a copy of originalData here in order be able
+    // to sort or filter rows without modifying the original
+    // array.
     self.viewData = Array.from(self.originalData);
-
-    self.data = [];
 
     self.applyFilters();
     self.orderings.sort();

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -794,15 +794,16 @@ export default function (self) {
    * @param {number} y The row index to start inserting the selection at.
    */
   self.moveTo = function (sel, x, y) {
-    var d = self.getSelectedData(),
-      s = self.getVisibleSchema(),
-      l = sel.length,
+    var selectedData = self.getSelectedData(),
+      visibleSchema = self.getVisibleSchema(),
+      selectionLength = sel.length,
       xi,
       maxRowLength = -Infinity,
       minXi = Infinity,
       yi = y - 1;
-    sel.forEach(function (row, index) {
-      if (index === l) {
+
+    sel.forEach(function (row, rowIndex) {
+      if (rowIndex === selectionLength) {
         return;
       }
       if (row.length === 0) {
@@ -813,17 +814,18 @@ export default function (self) {
       row.forEach(function (colIndex) {
         // intentional redef of colIndex
         colIndex = self.getVisibleColumnIndexOf(colIndex);
-        if (!s[colIndex]) {
+        if (!visibleSchema[colIndex]) {
           return;
         }
         // TODO:
-        if (!self.data[index]) {
-          self.data[index] = {};
+        if (!self.data[rowIndex]) {
+          self.data[rowIndex] = {};
         }
         // TODO:
-        self.data[index][s[colIndex].name] = null;
+        self.data[rowIndex][visibleSchema[colIndex].name] = null;
       });
     });
+
     sel.forEach(function (row, index) {
       var lastSourceIndex;
       yi += 1;
@@ -838,8 +840,8 @@ export default function (self) {
         lastSourceIndex = colIndex;
         if (
           colIndex === -1 ||
-          !s[xi] ||
-          !s[colIndex] ||
+          !visibleSchema[xi] ||
+          !visibleSchema[colIndex] ||
           // TODO:
           self.data.length - 1 < yi ||
           yi < 0
@@ -851,7 +853,8 @@ export default function (self) {
           self.data[yi] = {};
         }
         // TODO:
-        self.data[yi][s[xi].name] = d[index][s[colIndex].name];
+        self.data[yi][visibleSchema[xi].name] =
+          selectedData[index][visibleSchema[colIndex].name];
       });
     });
   };

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -37,6 +37,7 @@ export default function (self) {
     }
     self.validateColumn(c, s);
     s.splice(index, 0, c);
+    // TODO:
     self.data.forEach(function (row) {
       self.applyDefaultValue(row, c);
     });
@@ -55,6 +56,7 @@ export default function (self) {
   self.deleteColumn = function (index) {
     var s = self.getSchema();
     // remove data matching this column name from data
+    // TODO:
     self.data.forEach(function (row) {
       delete row[s[index].name];
     });
@@ -381,6 +383,7 @@ export default function (self) {
    */
   self.isColumnSelected = function (columnIndex) {
     var colIsSelected = true;
+    // TODO:
     self.data.forEach(function (row, rowIndex) {
       if (
         !self.selections[rowIndex] ||
@@ -403,6 +406,7 @@ export default function (self) {
   self.forEachSelectedCell = function (fn, expandToRow) {
     var d = [],
       s = expandToRow ? self.getSchema() : self.getVisibleSchema(),
+      // TODO:
       l = self.data.length;
     self.selections.forEach(function (row, index) {
       if (index === l) {
@@ -417,6 +421,7 @@ export default function (self) {
         if (col === -1 || !s[col]) {
           return;
         }
+        // TODO:
         fn(self.data, index, s[col].name);
       });
     });
@@ -434,6 +439,7 @@ export default function (self) {
   self.selectColumn = function (columnIndex, ctrl, shift, supressEvent) {
     var s, e, x;
     function addCol(i) {
+      // TODO:
       self.data.forEach(function (row, rowIndex) {
         self.selections[rowIndex] = self.selections[rowIndex] || [];
         if (self.selections[rowIndex].indexOf(i) === -1) {
@@ -442,6 +448,7 @@ export default function (self) {
       });
     }
     function removeCol(i) {
+      // TODO:
       self.data.forEach(function (row, rowIndex) {
         self.selections[rowIndex] = self.selections[rowIndex] || [];
         if (self.selections[rowIndex].indexOf(i) !== -1) {
@@ -551,6 +558,7 @@ export default function (self) {
   self.collapseTree = function (rowIndex) {
     self.dispatchEvent('collapsetree', {
       childGrid: self.childGrids[rowIndex],
+      // TODO:
       data: self.data[rowIndex],
       rowIndex: rowIndex,
     });
@@ -596,6 +604,7 @@ export default function (self) {
         offsetParent: self.intf.parentNode,
         parentNode: self.intf.parentNode,
         style: 'tree',
+        // TODO:
         data: self.data[rowIndex],
       };
       treeGrid = self.createGrid(trArgs);
@@ -605,6 +614,7 @@ export default function (self) {
     treeGrid.visible = true;
     self.dispatchEvent('expandtree', {
       treeGrid: treeGrid,
+      // TODO:
       data: self.data[rowIndex],
       rowIndex: rowIndex,
     });
@@ -811,9 +821,11 @@ export default function (self) {
         if (!s[colIndex]) {
           return;
         }
+        // TODO:
         if (!self.data[index]) {
           self.data[index] = {};
         }
+        // TODO:
         self.data[index][s[colIndex].name] = null;
       });
     });
@@ -833,14 +845,17 @@ export default function (self) {
           colIndex === -1 ||
           !s[xi] ||
           !s[colIndex] ||
+          // TODO:
           self.data.length - 1 < yi ||
           yi < 0
         ) {
           return;
         }
+        // TODO:
         if (!self.data[yi]) {
           self.data[yi] = {};
         }
+        // TODO:
         self.data[yi][s[xi].name] = d[index][s[colIndex].name];
       });
     });
@@ -1158,6 +1173,7 @@ export default function (self) {
    * @returns {schema} schema A schema based on the first item in the data array.
    */
   self.getSchemaFromData = function (d) {
+    // TODO:
     d = d || self.data;
     return Object.keys(d[0] || { ' ': '' }).map(function mapEachSchemaColumn(
       key,
@@ -1213,7 +1229,7 @@ export default function (self) {
     }
     if (
       self.selectionBounds.top < -1 ||
-      self.selectionBounds.bottom > self.data.length ||
+      self.selectionBounds.bottom > self.viewData.length ||
       self.selectionBounds.left < -1 ||
       self.selectionBounds.right > s.length
     ) {

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -191,7 +191,7 @@ export default function (self) {
     } else {
       self.columnFilters[column] = value;
     }
-    self.applyDataTransforms();
+    self.refresh();
   };
   /**
    * Returns the number of pixels to scroll down to line up with row rowIndex.

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -386,8 +386,7 @@ export default function (self) {
    */
   self.isColumnSelected = function (columnIndex) {
     var colIsSelected = true;
-    // TODO:
-    self.data.forEach(function (row, rowIndex) {
+    self.viewData.forEach(function (row, rowIndex) {
       if (
         !self.selections[rowIndex] ||
         self.selections[rowIndex].indexOf(self.orders.columns[columnIndex]) ===
@@ -409,8 +408,7 @@ export default function (self) {
   self.forEachSelectedCell = function (fn, expandToRow) {
     var d = [],
       s = expandToRow ? self.getSchema() : self.getVisibleSchema(),
-      // TODO:
-      l = self.data.length;
+      l = self.viewData.length;
     self.selections.forEach(function (row, index) {
       if (index === l) {
         return;
@@ -424,8 +422,7 @@ export default function (self) {
         if (col === -1 || !s[col]) {
           return;
         }
-        // TODO:
-        fn(self.data, index, s[col].name);
+        fn(self.viewData, index, s[col].name);
       });
     });
   };
@@ -442,8 +439,7 @@ export default function (self) {
   self.selectColumn = function (columnIndex, ctrl, shift, supressEvent) {
     var s, e, x;
     function addCol(i) {
-      // TODO:
-      self.data.forEach(function (row, rowIndex) {
+      self.viewData.forEach(function (row, rowIndex) {
         self.selections[rowIndex] = self.selections[rowIndex] || [];
         if (self.selections[rowIndex].indexOf(i) === -1) {
           self.selections[rowIndex].push(i);
@@ -451,8 +447,7 @@ export default function (self) {
       });
     }
     function removeCol(i) {
-      // TODO:
-      self.data.forEach(function (row, rowIndex) {
+      self.viewData.forEach(function (row, rowIndex) {
         self.selections[rowIndex] = self.selections[rowIndex] || [];
         if (self.selections[rowIndex].indexOf(i) !== -1) {
           self.selections[rowIndex].splice(
@@ -561,8 +556,7 @@ export default function (self) {
   self.collapseTree = function (rowIndex) {
     self.dispatchEvent('collapsetree', {
       childGrid: self.childGrids[rowIndex],
-      // TODO:
-      data: self.data[rowIndex],
+      data: self.viewData[rowIndex],
       rowIndex: rowIndex,
     });
     self.openChildren[rowIndex].blur();
@@ -607,8 +601,7 @@ export default function (self) {
         offsetParent: self.intf.parentNode,
         parentNode: self.intf.parentNode,
         style: 'tree',
-        // TODO:
-        data: self.data[rowIndex],
+        data: self.viewData[rowIndex],
       };
       treeGrid = self.createGrid(trArgs);
       self.childGrids[rowIndex] = treeGrid;
@@ -617,8 +610,7 @@ export default function (self) {
     treeGrid.visible = true;
     self.dispatchEvent('expandtree', {
       treeGrid: treeGrid,
-      // TODO:
-      data: self.data[rowIndex],
+      data: self.viewData[rowIndex],
       rowIndex: rowIndex,
     });
     self.openChildren[rowIndex] = treeGrid;
@@ -1176,8 +1168,7 @@ export default function (self) {
    * @returns {schema} schema A schema based on the first item in the data array.
    */
   self.getSchemaFromData = function (d) {
-    // TODO:
-    d = d || self.data;
+    d = d || self.originalData;
     return Object.keys(d[0] || { ' ': '' }).map(function mapEachSchemaColumn(
       key,
       index,

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -54,14 +54,15 @@ export default function (self) {
    * @param {number} index The index of the column to delete.
    */
   self.deleteColumn = function (index) {
-    var s = self.getSchema();
+    var schema = self.getSchema();
+
     // remove data matching this column name from data
-    // TODO:
-    self.data.forEach(function (row) {
-      delete row[s[index].name];
+    self.originalData.forEach(function (row) {
+      delete row[schema[index].name];
     });
-    s.splice(index, 1);
-    self.intf.schema = s;
+
+    schema.splice(index, 1);
+    self.intf.schema = schema;
 
     self.refresh();
   };

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -749,12 +749,12 @@ export default function (self) {
       direction,
       typeof f === 'function' ? f : self.sorters.string,
     );
-    self.orderings.sort();
+    self.refresh();
     self.dispatchEvent('sortcolumn', {
       name: columnName,
       direction: direction,
     });
-    self.draw(true);
+
     if (dontSetStorageData) {
       return;
     }

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -41,6 +41,8 @@ export default function (self) {
       self.applyDefaultValue(row, c);
     });
     self.intf.schema = s;
+
+    self.refresh();
   };
   /**
    * Deletes a column from the schema at the specified index.
@@ -58,6 +60,8 @@ export default function (self) {
     });
     s.splice(index, 1);
     self.intf.schema = s;
+
+    self.refresh();
   };
   /**
    * Adds a new column into the schema.
@@ -71,10 +75,12 @@ export default function (self) {
     var s = self.getSchema();
     self.validateColumn(c, s);
     s.push(c);
-    self.data.forEach(function (row) {
+    self.originalData.forEach(function (row) {
       self.applyDefaultValue(row, c);
     });
     self.intf.schema = s;
+
+    self.refresh();
   };
   /**
    * Deletes a row from the dataset at the specified index.
@@ -106,7 +112,10 @@ export default function (self) {
         self.applyDefaultValue(self.originalData[index], c);
       }
     });
+
+    // setFilter calls .refresh(), so we need not call it again:
     self.setFilter();
+
     self.resize(true);
   };
   /**
@@ -126,7 +135,10 @@ export default function (self) {
         );
       }
     });
+
+    // setFilter calls .refresh(), so we need not call it again:
     self.setFilter();
+
     self.resize(true);
   };
   /**
@@ -353,7 +365,7 @@ export default function (self) {
       top: 0,
       left: -1,
       right: self.getSchema().length - 1,
-      bottom: self.data.length - 1,
+      bottom: self.viewData.length - 1,
     });
     if (dontDraw) {
       return;
@@ -714,7 +726,7 @@ export default function (self) {
     }
     self.orderBy = columnName;
     self.orderDirection = direction;
-    if (!self.data || self.data.length === 0) {
+    if (!self.viewData || self.viewData.length === 0) {
       return;
     }
     if (c.length === 0) {
@@ -1248,7 +1260,9 @@ export default function (self) {
       self.ctx.font = self.style.rowHeaderCellFont;
       return (
         self.ctx.measureText(
-          (self.data.length + (self.attributes.showNewRow ? 1 : 0)).toString(),
+          (
+            self.viewData.length + (self.attributes.showNewRow ? 1 : 0)
+          ).toString(),
         ).width +
         self.style.autosizePadding +
         self.style.autosizeHeaderCellPadding +
@@ -1274,7 +1288,7 @@ export default function (self) {
       m = t > m ? t : m;
       formatter = self.formatters[col.type];
     });
-    self.data.forEach(function (row) {
+    self.viewData.forEach(function (row) {
       var text = row[name];
       if (formatter) {
         text = formatter({ cell: { value: text } });

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -216,7 +216,9 @@ export default function (self) {
    */
   self.findRowScrollTop = function (rowIndex) {
     if (self.scrollCache.y[rowIndex] === undefined) {
-      throw new RangeError('Row index out of range.');
+      throw new RangeError(
+        `Row index ${rowIndex} out of range: ${self.scrollCache.y.length}.`,
+      );
     }
     return self.scrollCache.y[rowIndex];
   };

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -37,8 +37,8 @@ export default function (self) {
     }
     self.validateColumn(c, s);
     s.splice(index, 0, c);
-    // TODO:
-    self.data.forEach(function (row) {
+
+    self.originalData.forEach(function (row) {
       self.applyDefaultValue(row, c);
     });
     self.intf.schema = s;

--- a/lib/touch.js
+++ b/lib/touch.js
@@ -267,7 +267,7 @@ export default function (self) {
           if (self.attributes.columnHeaderClickBehavior === 'select') {
             self.selectArea({
               top: 0,
-              bottom: self.data.length - 1,
+              bottom: self.viewData.length - 1,
               left: self.startingCell.columnIndex,
               right: self.startingCell.columnIndex,
             });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "canvas-datagrid",
-  "version": "0.25.2",
+  "version": "0.25.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1742,6 +1742,12 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1973,6 +1979,20 @@
         "lodash": "^4.17.14"
       }
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1983,6 +2003,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "3.4.3",
@@ -2330,6 +2356,15 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -3207,6 +3242,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-intrinsic": {
@@ -4094,6 +4135,12 @@
           "dev": true
         }
       }
+    },
+    "karma-chai": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/karma-chai/-/karma-chai-0.1.0.tgz",
+      "integrity": "sha1-vuWtQEAFF4Ea40u5RfdikJEIt5o=",
+      "dev": true
     },
     "karma-chrome-launcher": {
       "version": "3.1.0",
@@ -5180,6 +5227,12 @@
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -6091,6 +6144,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1369,10 +1369,26 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/node": {
@@ -1660,6 +1676,12 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "dev": true
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -1696,6 +1718,12 @@
         }
       }
     },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -1730,10 +1758,55 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-back": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
       "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
+      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arraybuffer.slice": {
@@ -1748,6 +1821,12 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1760,10 +1839,22 @@
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
     "babel-loader": {
@@ -1800,6 +1891,61 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "base64-arraybuffer": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
@@ -1810,6 +1956,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
     "better-assert": {
@@ -1832,6 +1984,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "blob": {
       "version": "0.0.5",
@@ -1880,6 +2042,20 @@
         }
       }
     },
+    "bonjour": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "dev": true,
+      "requires": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1924,6 +2100,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
@@ -1935,6 +2117,23 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
       "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
     },
     "call-bind": {
       "version": "1.0.0",
@@ -2040,6 +2239,29 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -2168,6 +2390,16 @@
         }
       }
     },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2237,6 +2469,53 @@
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2272,6 +2551,21 @@
         }
       }
     },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -2293,6 +2587,18 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-js-compat": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.0.tgz",
@@ -2311,6 +2617,12 @@
         }
       }
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
@@ -2322,6 +2634,19 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "custom-event": {
@@ -2351,6 +2676,12 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -2364,6 +2695,20 @@
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "deep-extend": {
@@ -2384,6 +2729,57 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
+    "default-gateway": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+      "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        }
+      }
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -2393,10 +2789,86 @@
         "object-keys": "^1.0.12"
       }
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "del": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
+        }
+      }
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==",
       "dev": true
     },
     "di": {
@@ -2410,6 +2882,31 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "dev": true
+    },
+    "dns-packet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
+      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "dev": true,
+      "requires": {
+        "buffer-indexof": "^1.0.0"
+      }
     },
     "doctrine": {
       "version": "3.0.0",
@@ -2598,6 +3095,15 @@
       "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
       "dev": true
     },
+    "errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2605,6 +3111,36 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "escalade": {
@@ -2977,6 +3513,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -2988,6 +3530,15 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
       "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg==",
       "dev": true
+    },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "dev": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
     },
     "execa": {
       "version": "4.1.0",
@@ -3049,11 +3600,214 @@
         }
       }
     },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "cookie": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -3079,6 +3833,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "faye-websocket": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -3096,6 +3859,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -3196,6 +3966,33 @@
       "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==",
       "dev": true
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -3282,6 +4079,12 @@
         "pump": "^3.0.0"
       }
     },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "glob": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
@@ -3316,6 +4119,41 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -3326,6 +4164,12 @@
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "handle-thing": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
     "handlebars": {
@@ -3385,16 +4229,92 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
+    "html-entities": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.4.0.tgz",
+      "integrity": "sha512-8nxjcBcd8wovbeKx7h3wTji4e6+rhaVuPNpMqwWgnHh+N9ToqsCs6XztWRBPQ+UtzsoMAdKZtUENoVzU/EMtZA==",
+      "dev": true
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
@@ -3418,6 +4338,12 @@
         }
       }
     },
+    "http-parser-js": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.3.tgz",
+      "integrity": "sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==",
+      "dev": true
+    },
     "http-proxy": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -3427,6 +4353,18 @@
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+      "dev": true,
+      "requires": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
       }
     },
     "human-signals": {
@@ -3670,11 +4608,74 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "internal-ip": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
+      "integrity": "sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==",
+      "dev": true,
+      "requires": {
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
+      }
+    },
     "interpret": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arguments": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+      "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -3690,6 +4691,69 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -3730,11 +4794,44 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^2.1.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+      "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.2"
+      }
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-printable-key-event": {
       "version": "1.0.0",
@@ -3750,6 +4847,15 @@
         "@types/estree": "*"
       }
     },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
@@ -3760,6 +4866,27 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
@@ -3778,6 +4905,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "istanbul": {
@@ -4056,6 +5189,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json3": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==",
+      "dev": true
+    },
     "json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -4238,6 +5377,18 @@
       "requires": {
         "minimist": "^1.2.3"
       }
+    },
+    "killable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
+      "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
     },
     "klaw": {
       "version": "3.0.0",
@@ -4623,6 +5774,12 @@
         "streamroller": "^2.2.4"
       }
     },
+    "loglevel": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
@@ -4640,6 +5797,21 @@
       "requires": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
       }
     },
     "markdown-it": {
@@ -4679,11 +5851,138 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
     },
     "mime": {
       "version": "2.4.6",
@@ -4712,6 +6011,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -4726,6 +6031,27 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.5",
@@ -4992,11 +6318,53 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "multicast-dns": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
+      "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+      "dev": true,
+      "requires": {
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanoid": {
       "version": "3.1.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
       "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
       "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5014,6 +6382,18 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-releases": {
@@ -5054,17 +6434,79 @@
         }
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
     "object-component": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-inspect": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.4.tgz",
+      "integrity": "sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
     },
     "object.assign": {
       "version": "4.1.2",
@@ -5078,6 +6520,21 @@
         "object-keys": "^1.1.1"
       }
     },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -5086,6 +6543,12 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -5111,6 +6574,15 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
       "dev": true
     },
+    "opn": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
+      "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
     "optionator": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -5124,6 +6596,21 @@
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
       }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
@@ -5150,6 +6637,15 @@
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
+      }
+    },
+    "p-retry": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
+      "integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
+      "dev": true,
+      "requires": {
+        "retry": "^0.12.0"
       }
     },
     "p-try": {
@@ -5203,6 +6699,18 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -5215,10 +6723,28 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
     "path-type": {
@@ -5245,6 +6771,21 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -5262,6 +6803,43 @@
       "requires": {
         "semver-compare": "^1.0.0"
       }
+    },
+    "portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -5284,10 +6862,32 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
     "pump": {
@@ -5318,6 +6918,18 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -5343,6 +6955,29 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
       }
     },
     "readdirp": {
@@ -5399,6 +7034,26 @@
         "@babel/runtime": "^7.8.4"
       }
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -5441,6 +7096,24 @@
           "dev": true
         }
       }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -5493,6 +7166,12 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -5502,6 +7181,18 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
     },
     "rfdc": {
       "version": "1.1.4",
@@ -5629,6 +7320,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5644,6 +7344,21 @@
         "@types/json-schema": "^7.0.5",
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
+      }
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "dev": true
+    },
+    "selfsigned": {
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {
@@ -5664,6 +7379,58 @@
       "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
       "dev": true
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
@@ -5673,16 +7440,122 @@
         "randombytes": "^2.1.0"
       }
     },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "signal-exit": {
@@ -5706,6 +7579,128 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
     "socket.io": {
@@ -5803,6 +7798,42 @@
         "isarray": "2.0.1"
       }
     },
+    "sockjs": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.21.tgz",
+      "integrity": "sha512-DhbPFGpxjc6Z3I+uX07Id5ZO2XwYsWOrYjaSeieES78cq+JaJvVe5q/m1uvjIQhXinhIeCFRH6JgXe+mvVMyXw==",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^3.4.0",
+        "websocket-driver": "^0.7.4"
+      }
+    },
+    "sockjs-client": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.0.tgz",
+      "integrity": "sha512-8Dt3BDi4FYNrCFGTL/HtwVzkARrENdwOUf1ZoW/9p3M8lZdFT35jVdrHza+qgxuG9H3/shR4cuX/X9umUrjP8Q==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.4.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -5814,6 +7845,19 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
     },
     "source-map-support": {
       "version": "0.5.19",
@@ -5833,17 +7877,93 @@
         }
       }
     },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
+    "spdy": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      }
+    },
+    "spdy-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "statuses": {
       "version": "1.5.0",
@@ -5904,6 +8024,35 @@
         }
       }
     },
+    "string.prototype.trimend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -5923,6 +8072,12 @@
       "requires": {
         "ansi-regex": "^5.0.0"
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -6069,6 +8224,12 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "dev": true
+    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -6114,6 +8275,38 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -6226,6 +8419,18 @@
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6238,6 +8443,58 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
@@ -6247,16 +8504,74 @@
         "punycode": "^2.1.0"
       }
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
     "v8-compile-cache": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "void-elements": {
@@ -6273,6 +8588,15 @@
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "webpack": {
@@ -6410,6 +8734,405 @@
         }
       }
     },
+    "webpack-dev-middleware": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz",
+      "integrity": "sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==",
+      "dev": true,
+      "requires": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      }
+    },
+    "webpack-dev-server": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.1.tgz",
+      "integrity": "sha512-u4R3mRzZkbxQVa+MBWi2uVpB5W59H3ekZAJsQlKUTdl7Elcah2EhygTPLmeFXybQkf9i2+L0kn7ik9SnXa6ihQ==",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.3.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.8",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.26",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.8",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.21",
+        "sockjs-client": "^1.5.0",
+        "spdy": "^4.0.2",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "import-local": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+          "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+          "dev": true,
+          "requires": {
+            "pkg-dir": "^3.0.0",
+            "resolve-cwd": "^2.0.0"
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+          "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+          "dev": true,
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-2.0.0.tgz",
+      "integrity": "sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+          "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+          "dev": true
+        }
+      }
+    },
     "webpack-merge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
@@ -6436,6 +9159,23 @@
           "dev": true
         }
       }
+    },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build-docs": "rm -rf docs; npm run build; jsdoc -c ./jsdoc.conf.js; cp dist/canvas-datagrid.* docs/; cp -r tutorials/* images docs/",
     "format": "prettier lib/**/*.js --write",
     "lint": "eslint lib",
+    "start": "webpack serve --open",
     "test": "npm run build; karma start",
     "test:watch": "karma start --no-single-run",
     "watch": "webpack --watch"
@@ -88,7 +89,8 @@
     "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-terser": "^7.0.2",
     "webpack": "^5.6.0",
-    "webpack-cli": "^4.2.0"
+    "webpack-cli": "^4.2.0",
+    "webpack-dev-server": "^3.11.1"
   },
   "dependencies": {
     "is-printable-key-event": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "prettier lib/**/*.js --write",
     "lint": "eslint lib",
     "test": "npm run build; karma start",
+    "test:watch": "karma start --no-single-run",
     "watch": "webpack --watch"
   },
   "files": [
@@ -66,6 +67,7 @@
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/plugin-replace": "^2.3.4",
     "babel-loader": "^8.2.1",
+    "chai": "^4.2.0",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
@@ -73,6 +75,7 @@
     "istanbul": "^0.4.5",
     "jsdoc": "^3.6.6",
     "karma": "^5.2.3",
+    "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.2",
     "karma-coverage-istanbul-reporter": "^3.0.2",

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -170,7 +170,7 @@ export default function () {
       data: [{ a: 'a' }],
     });
     grid.style.cellBackgroundColor = c.y;
-    assertIf(grid.data.length !== 1, 'Expected there to be exactly 1 row.');
+    assertIf(grid.viewData.length !== 1, 'Expected there to be exactly 1 row.');
     assertPxColor(grid, 60, 60, c.y, done);
   });
   it('Should insert data into the new row', function (done) {
@@ -191,7 +191,10 @@ export default function () {
         return done(err);
       }
       done(
-        assertIf(grid.data.length !== 2, 'expected there to be exactly 3 row.'),
+        assertIf(
+          grid.viewData.length !== 2,
+          'expected there to be exactly 3 row.',
+        ),
       );
     });
   });
@@ -240,7 +243,7 @@ export default function () {
           setTimeout(function () {
             done(
               assertIf(
-                grid.data[0].col1 !== 'bar',
+                grid.viewData[0].col1 !== 'bar',
                 'Expected data to be ordered when new grid is created',
               ),
             );
@@ -394,7 +397,7 @@ export default function () {
           setTimeout(function () {
             done(
               assertIf(
-                grid.data[0].col1 !== 'foo',
+                grid.viewData[0].col1 !== 'foo',
                 'Expected data to be ordered when new grid is created',
               ),
             );
@@ -571,7 +574,9 @@ export default function () {
     marker(grid, 60, 12);
     mousemove(grid.canvas, 60, 12);
     click(grid.canvas, 60, 12);
-    done(assertIf(grid.data[0].col1 !== 'bar', 'Expected data to be sorted.'));
+    done(
+      assertIf(grid.viewData[0].col1 !== 'bar', 'Expected data to be sorted.'),
+    );
   });
   it('Clicking a header cell with columnHeaderClickBehavior set to select should select the column', function (done) {
     var grid = g({

--- a/test/context-menu.js
+++ b/test/context-menu.js
@@ -28,7 +28,7 @@ export default function () {
         e.items[4].contextItemContainer.dispatchEvent(new Event('click'));
         done(
           assertIf(
-            grid.data[0].col1 !== 'bar',
+            grid.viewData[0].col1 !== 'bar',
             'Expected the content to be reordered asc.',
           ),
         );
@@ -229,7 +229,7 @@ export default function () {
 
           if (key === 'Enter') {
             err = assertIf(
-              grid.data[0].col1 !== 'baz',
+              grid.viewData[0].col1 !== 'baz',
               'Expected key combination to filter for baz',
             );
           }
@@ -259,7 +259,7 @@ export default function () {
 
           if (key === 'Enter') {
             err = assertIf(
-              grid.data[0].col1 !== 'bar',
+              grid.viewData[0].col1 !== 'bar',
               'Expected key combination to filter for bar',
             );
           }
@@ -287,7 +287,7 @@ export default function () {
           i.dispatchEvent(ev);
           if (key === 'Tab') {
             err = assertIf(
-              grid.data[0].col1 !== 'foo',
+              grid.viewData[0].col1 !== 'foo',
               'Expected key combination to filter for bar',
             );
           }
@@ -315,7 +315,7 @@ export default function () {
           i.dispatchEvent(ev);
           if (key === 'esc') {
             err = assertIf(
-              grid.data[0].col1 !== 'foo',
+              grid.viewData[0].col1 !== 'foo',
               'Expected key combination to filter for bar',
             );
           }

--- a/test/data-interface.js
+++ b/test/data-interface.js
@@ -12,7 +12,7 @@ export default function () {
     ];
     done(
       assertIf(
-        grid.data[2].c !== 9,
+        grid.viewData[2].c !== 9,
         'Expected grid to be able to import and export this format',
       ),
     );
@@ -58,7 +58,7 @@ export default function () {
     grid.data = [['a', 'b', 'c'], ['1', '2'], ['q']];
     done(
       assertIf(
-        grid.data[0][0] !== 'a',
+        grid.viewData[0][0] !== 'a',
         'Expected grid to be able to import and export this format',
       ),
     );

--- a/test/editing.js
+++ b/test/editing.js
@@ -44,7 +44,9 @@ export default function () {
     ev.key = 'Enter';
     grid.input.value = 'blah';
     grid.addEventListener('endedit', function () {
-      done(assertIf(grid.data[0].d !== 'blah', 'Expected value to be in data'));
+      done(
+        assertIf(grid.viewData[0].d !== 'blah', 'Expected value to be in data'),
+      );
     });
     grid.input.dispatchEvent(ev);
   });
@@ -60,7 +62,9 @@ export default function () {
     grid.input.value = 'blah';
     grid.addEventListener('beforeendedit', function (e) {
       e.abort();
-      done(assertIf(grid.data[0].d === 'blah', 'Expected value to be in data'));
+      done(
+        assertIf(grid.viewData[0].d === 'blah', 'Expected value to be in data'),
+      );
     });
     grid.input.dispatchEvent(ev);
   });
@@ -185,7 +189,7 @@ export default function () {
     });
 
     setTimeout(function () {
-      var cellData = grid.data[0]['Column A'];
+      var cellData = grid.viewData[0]['Column A'];
       done(
         assertIf(
           cellData !== 'Paste buffer value',
@@ -220,7 +224,7 @@ export default function () {
     });
 
     setTimeout(function () {
-      var cellData = grid.data[0]['Column A'];
+      var cellData = grid.viewData[0]['Column A'];
       done(
         assertIf(
           cellData !== 'Paste buffer value',
@@ -255,7 +259,7 @@ export default function () {
     });
 
     setTimeout(function () {
-      var cellData = grid.data[0]['Column A'];
+      var cellData = grid.viewData[0]['Column A'];
       done(
         assertIf(
           cellData !== 'Paste buffer value',

--- a/test/filters.js
+++ b/test/filters.js
@@ -9,7 +9,7 @@ export default function () {
     grid.setFilter('d', 'edfg');
     done(
       assertIf(
-        grid.data.length === 0 && grid.data[0].d === 'edfg',
+        grid.viewData.length === 0 && grid.viewData[0].d === 'edfg',
         'Expected filter to remove all but 1 row.',
       ),
     );
@@ -27,7 +27,7 @@ export default function () {
       ],
     });
     grid.setFilter('d', '(Blanks)');
-    var filteredValuesOnly = grid.data.map((obj) => obj.d);
+    var filteredValuesOnly = grid.viewData.map((obj) => obj.d);
     var onlyBlanks =
       filteredValuesOnly.length === 4 &&
       filteredValuesOnly.every((item) =>
@@ -42,7 +42,7 @@ export default function () {
       schema: [{ name: 'd', type: 'number' }],
     });
     grid.setFilter('d', '(Blanks)');
-    var filteredValuesOnly = grid.data.map((obj) => obj.d);
+    var filteredValuesOnly = grid.viewData.map((obj) => obj.d);
     var onlyBlanks =
       filteredValuesOnly.length === 3 &&
       filteredValuesOnly.every((item) => [undefined, null, ''].includes(item));
@@ -61,7 +61,7 @@ export default function () {
     grid.setFilter();
     done(
       assertIf(
-        grid.data.length !== 2,
+        grid.viewData.length !== 2,
         'Expected to see all the records return.',
       ),
     );
@@ -77,7 +77,9 @@ export default function () {
     grid.setFilter('d', 'edfg');
     grid.setFilter('e', 'asdfg');
     grid.setFilter('e', '');
-    done(assertIf(grid.data.length !== 1, 'Expected to see 1 of the records.'));
+    done(
+      assertIf(grid.viewData.length !== 1, 'Expected to see 1 of the records.'),
+    );
   });
   it('Should remove a specific filter by passing undefined', function (done) {
     var grid = g({
@@ -90,7 +92,9 @@ export default function () {
     grid.setFilter('d', 'edfg');
     grid.setFilter('e', 'asdfg');
     grid.setFilter('e');
-    done(assertIf(grid.data.length !== 1, 'Expected to see 1 of the records.'));
+    done(
+      assertIf(grid.viewData.length !== 1, 'Expected to see 1 of the records.'),
+    );
   });
   it('Should use RegExp as a filter', function (done) {
     var grid = g({
@@ -100,7 +104,7 @@ export default function () {
     grid.setFilter('d', '/\\w/');
     done(
       assertIf(
-        grid.data.length === 0 && grid.data[0].d === 'edfg',
+        grid.viewData.length === 0 && grid.viewData[0].d === 'edfg',
         'Expected to see a row after a RegExp value.',
       ),
     );
@@ -120,7 +124,9 @@ export default function () {
     });
     grid.setFilter('d', 'a');
     grid.setFilter('x', 'a');
-    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+    done(
+      assertIf(grid.viewData.length !== 1, 'Expected to see only 1 record.'),
+    );
   });
   it('Should apply correct type filtering method when column filter not set', function (done) {
     var grid = g({
@@ -135,7 +141,9 @@ export default function () {
     });
     delete grid.schema[0].filter;
     grid.setFilter('num', '1');
-    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+    done(
+      assertIf(grid.viewData.length !== 1, 'Expected to see only 1 record.'),
+    );
   });
   it('Should apply filter to new data when data is set', function (done) {
     var grid = g({
@@ -144,7 +152,9 @@ export default function () {
     });
     grid.setFilter('d', 'a');
     grid.data = [{ d: 'gfde' }, { d: 'dcba' }];
-    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+    done(
+      assertIf(grid.viewData.length !== 1, 'Expected to see only 1 record.'),
+    );
   });
   it('Should retain filters of columns not in new data when data is set', function (done) {
     var grid = g({
@@ -156,6 +166,8 @@ export default function () {
     grid.data = [{ x: 'aaaa' }, { x: 'aaaa' }];
     grid.data = [{ d: 'gfde' }, { d: 'dcba' }];
 
-    done(assertIf(grid.data.length !== 1, 'Expected to see only 1 record.'));
+    done(
+      assertIf(grid.viewData.length !== 1, 'Expected to see only 1 record.'),
+    );
   });
 }

--- a/test/instantation.js
+++ b/test/instantation.js
@@ -24,7 +24,10 @@ export default function () {
       data: smallData(),
     });
     grid.style.activeCellBackgroundColor = c.b;
-    assertIf(grid.data.length !== 3, 'Expected to see data in the interface.');
+    assertIf(
+      grid.viewData.length !== 3,
+      'Expected to see data in the interface.',
+    );
     assertPxColor(grid, 80, 32, c.b, done);
   });
 }

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -180,8 +180,9 @@ export default function () {
     });
     grid.setFilter('col1', 'foo');
 
-    assert.notDeepEqual(grid.viewData, data);
-    assert.deepEqual(grid.viewData, grid.data);
+    const matchingRows = data.filter((row) => row.col1 === 'foo');
+
+    assert.deepEqual(grid.viewData, matchingRows);
   });
   it('Property `viewData` should be equal to sorted data', function () {
     const data = smallData();
@@ -191,8 +192,9 @@ export default function () {
     });
     grid.order('col1', 'asc');
 
-    assert.notDeepEqual(grid.viewData, data);
-    assert.deepEqual(grid.viewData, grid.data);
+    const sortedRows = [data[1], data[2], data[0]];
+
+    assert.deepEqual(grid.viewData, sortedRows);
   });
   it('Property `boundData` should be equal to original source data', function () {
     const data = smallData();

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -42,7 +42,7 @@ export default function () {
     );
     done(
       assertIf(
-        grid.schema[1].name !== 'f' || grid.data[0].f !== 'g',
+        grid.schema[1].name !== 'f' || grid.viewData[0].f !== 'g',
         'Expected to see a specific column here, it is not here.',
       ),
     );
@@ -64,7 +64,7 @@ export default function () {
     );
     done(
       assertIf(
-        grid.schema[1].name !== 'f' || grid.data[0].f !== 'g',
+        grid.schema[1].name !== 'f' || grid.viewData[0].f !== 'g',
         'Expected to see a specific column here, it is not here.',
       ),
     );
@@ -265,7 +265,7 @@ export default function () {
     grid.deleteColumn(0);
     done(
       assertIf(
-        Object.keys(grid.data[0])[0] === n || grid.schema[0].name === n,
+        Object.keys(grid.viewData[0])[0] === n || grid.schema[0].name === n,
         'Expected to see column 0 deleted, but it appears to still be there.',
       ),
     );
@@ -284,7 +284,7 @@ export default function () {
     l = grid.schema.length - 1;
     done(
       assertIf(
-        grid.schema[l].name !== 'f' || grid.data[0].f !== 'g',
+        grid.schema[l].name !== 'f' || grid.viewData[0].f !== 'g',
         'Expected to see a specific column here, it is not here.',
       ),
     );
@@ -297,10 +297,10 @@ export default function () {
         schema: [{ name: 'd' }, { name: 'e', defaultValue: 10 }],
       });
     grid.addRow({ d: '1' });
-    l = grid.data.length - 1;
+    l = grid.viewData.length - 1;
     done(
       assertIf(
-        grid.data[l].d !== '1' || grid.data[l].e !== 10,
+        grid.viewData[l].d !== '1' || grid.viewData[l].e !== 10,
         'Expected to see a specific row here, it is not here.',
       ),
     );
@@ -317,7 +317,7 @@ export default function () {
     grid.insertRow({ d: '6' }, 1);
     done(
       assertIf(
-        grid.data[2].d !== '3' || grid.data[1].e !== 10,
+        grid.viewData[2].d !== '3' || grid.viewData[1].e !== 10,
         'Expected to see a specific row here, it is not here.',
       ),
     );
@@ -345,7 +345,7 @@ export default function () {
     grid.deleteRow(1);
     done(
       assertIf(
-        grid.data.length !== 1 || grid.data[0].d !== '1',
+        grid.viewData.length !== 1 || grid.viewData[0].d !== '1',
         'Expected to see only 1 row, expected row 1 to contain a specific value.',
       ),
     );

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -163,6 +163,24 @@ export default function () {
       ),
     );
   });
+  it('Property `boundData` should be equal to original source data', function () {
+    const data = smallData();
+    const grid = g({
+      test: this.test,
+      data,
+    });
+
+    assert.deepStrictEqual(grid.boundData, data);
+
+    grid.setFilter('col1', 'foo');
+    grid.order('col1', 'desc');
+
+    assert.deepStrictEqual(
+      grid.boundData,
+      data,
+      'filtering/sorting does not affect boundData',
+    );
+  });
   it('Get offsetLeft of the parent node', function (done) {
     var grid = g({
       test: this.test,

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -163,7 +163,7 @@ export default function () {
       ),
     );
   });
-  describe.only('improvements', function () {
+  describe('improvements', function () {
     it("Current cell's viewRowIndex and viewColumnIndex are equal to rowIndex and columnIndex, when not filtering", function (done) {
       const grid = g({
         test: this.test,

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -163,6 +163,72 @@ export default function () {
       ),
     );
   });
+  it("Current cell's viewRowIndex and viewColumnIndex are equal to rowIndex and columnIndex, when not filtering", function (done) {
+    var grid = g({
+      test: this.test,
+      data: [
+        { d: '123456', e: 'foo bar', f: 'abc def' },
+        { d: '123456', e: 'foo bar', f: 'abc def' },
+        { d: '123456', e: 'foo bar', f: 'selected' }, // <-- active cell
+        { d: '123456', e: 'foo bar', f: 'abc def' },
+      ],
+    });
+
+    grid.setActiveCell(2, 2);
+
+    try {
+      assert.equal(grid.activeCell.rowIndex, 2, 'rowIndex = 2');
+      assert.equal(grid.activeCell.columnIndex, 2, 'columnIndex = 2');
+      assert.equal(
+        grid.activeCell.viewRowIndex,
+        grid.activeCell.rowIndex,
+        'viewRowIndex equal to rowIndex',
+      );
+      assert.equal(
+        grid.activeCell.viewColumnIndex,
+        grid.activeCell.columnIndex,
+        'viewColumnIndex equal to columnIndex',
+      );
+    } catch (error) {
+      return done(error);
+    }
+
+    done();
+  });
+  it("Current cell's viewRowIndex and viewColumnIndex are NOT equal to rowIndex and columnIndex, when filtering", function (done) {
+    var grid = g({
+      test: this.test,
+      data: [
+        { d: '123456', e: 'foo bar', f: 'abc def' },
+        { d: '123456', e: 'foo bar', f: 'abc def' },
+        { d: '123456', e: 'foo bar', f: 'selected' },
+        { d: '123456', e: 'foo bar', f: 'abc def' },
+      ],
+    });
+
+    grid.setActiveCell(2, 2);
+    grid.setFilter('f', 'selected');
+
+    try {
+      assert.equal(
+        grid.activeCell.rowIndex,
+        2,
+        'rowIndex is position in originalData',
+      );
+      assert.equal(grid.activeCell.columnIndex, 2, 'columnIndex unchanged');
+      assert.equal(
+        grid.activeCell.viewRowIndex,
+        0,
+        'viewRowIndex is position in viewData',
+      );
+      assert.equal(grid.activeCell.viewColumnIndex, 1, 'viewColumnIndex = 1');
+    } catch (error) {
+      return done(error);
+    }
+
+    done();
+  });
+
   it('Property `viewData` should be deeply equal to source data, if not filtered', function () {
     const data = smallData();
     const grid = g({

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -163,6 +163,37 @@ export default function () {
       ),
     );
   });
+  it('Property `viewData` should be deeply equal to source data, if not filtered', function () {
+    const data = smallData();
+    const grid = g({
+      test: this.test,
+      data,
+    });
+
+    assert.deepEqual(grid.viewData, data);
+  });
+  it('Property `viewData` should be equal to filtered data', function () {
+    const data = smallData();
+    const grid = g({
+      test: this.test,
+      data,
+    });
+    grid.setFilter('col1', 'foo');
+
+    assert.notDeepEqual(grid.viewData, data);
+    assert.deepEqual(grid.viewData, grid.data);
+  });
+  it('Property `viewData` should be equal to sorted data', function () {
+    const data = smallData();
+    const grid = g({
+      test: this.test,
+      data,
+    });
+    grid.order('col1', 'asc');
+
+    assert.notDeepEqual(grid.viewData, data);
+    assert.deepEqual(grid.viewData, grid.data);
+  });
   it('Property `boundData` should be equal to original source data', function () {
     const data = smallData();
     const grid = g({

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -163,70 +163,97 @@ export default function () {
       ),
     );
   });
-  it("Current cell's viewRowIndex and viewColumnIndex are equal to rowIndex and columnIndex, when not filtering", function (done) {
-    var grid = g({
-      test: this.test,
-      data: [
-        { d: '123456', e: 'foo bar', f: 'abc def' },
-        { d: '123456', e: 'foo bar', f: 'abc def' },
-        { d: '123456', e: 'foo bar', f: 'selected' }, // <-- active cell
-        { d: '123456', e: 'foo bar', f: 'abc def' },
-      ],
+  describe.only('improvements', function () {
+    it("Current cell's viewRowIndex and viewColumnIndex are equal to rowIndex and columnIndex, when not filtering", function (done) {
+      const grid = g({
+        test: this.test,
+        schema: [
+          {
+            name: 'd',
+          },
+          {
+            name: 'e',
+          },
+          {
+            name: 'f',
+          },
+        ],
+        data: [
+          { d: '123456 0x0', e: 'foo bar 0x1', f: 'abc def' },
+          { d: '123456 1x0', e: 'foo bar 1x1', f: 'abc def' },
+          { d: '123456 2x0', e: 'foo bar 2x1', f: 'abc def' },
+          { d: '123456 3x0', e: 'foo bar 3x1', f: 'abc def' },
+        ],
+      });
+
+      const cell = grid.getVisibleCellByIndex(1, 1);
+
+      try {
+        assert.equal(cell.value, 'foo bar 1x1');
+        assert.equal(cell.rowIndex, 1, 'rowIndex = 1');
+        assert.equal(cell.columnIndex, 1, 'columnIndex = 1');
+        assert.equal(
+          cell.viewRowIndex,
+          cell.boundRowIndex,
+          'viewRowIndex == boundRowIndex',
+        );
+        assert.equal(
+          cell.viewColumnIndex,
+          cell.boundColumnIndex,
+          'viewColumnIndex == boundColumnIndex',
+        );
+      } catch (error) {
+        return done(error);
+      }
+
+      done();
     });
+    it("Current cell's viewRowIndex != rowIndex, when filtering", function (done) {
+      var grid = g({
+        test: this.test,
+        schema: [
+          {
+            name: 'd',
+          },
+          {
+            name: 'e',
+          },
+          {
+            name: 'f',
+          },
+        ],
+        data: [
+          { d: '123456', e: 'foo bar', f: 'abc def' },
+          { d: '123456', e: 'selected', f: 'abc def' }, // <-- cell
+          { d: '123456', e: 'foo bar', f: 'abc def' },
+          { d: '123456', e: 'foo bar', f: 'abc def' },
+        ],
+      });
 
-    grid.setActiveCell(2, 2);
+      grid.setFilter('e', 'selected');
 
-    try {
-      assert.equal(grid.activeCell.rowIndex, 2, 'rowIndex = 2');
-      assert.equal(grid.activeCell.columnIndex, 2, 'columnIndex = 2');
-      assert.equal(
-        grid.activeCell.viewRowIndex,
-        grid.activeCell.rowIndex,
-        'viewRowIndex equal to rowIndex',
-      );
-      assert.equal(
-        grid.activeCell.viewColumnIndex,
-        grid.activeCell.columnIndex,
-        'viewColumnIndex equal to columnIndex',
-      );
-    } catch (error) {
-      return done(error);
-    }
+      const cell = grid.getVisibleCellByIndex(1, 0);
 
-    done();
-  });
-  it("Current cell's viewRowIndex and viewColumnIndex are NOT equal to rowIndex and columnIndex, when filtering", function (done) {
-    var grid = g({
-      test: this.test,
-      data: [
-        { d: '123456', e: 'foo bar', f: 'abc def' },
-        { d: '123456', e: 'foo bar', f: 'abc def' },
-        { d: '123456', e: 'foo bar', f: 'selected' },
-        { d: '123456', e: 'foo bar', f: 'abc def' },
-      ],
+      try {
+        assert.equal(cell.value, 'selected');
+        assert.equal(
+          cell.boundRowIndex,
+          1,
+          'rowIndex = 1 -> position in originalData',
+        );
+        assert.equal(cell.boundColumnIndex, 1, 'columnIndex unchanged');
+        assert.equal(
+          cell.viewRowIndex,
+          0,
+          'viewRowIndex = 0 -> position in viewData (filtered)',
+        );
+        assert.equal(cell.viewColumnIndex, 1, 'viewColumnIndex = 1');
+      } catch (error) {
+        return done(error);
+      }
+
+      done();
     });
-
-    grid.setActiveCell(2, 2);
-    grid.setFilter('f', 'selected');
-
-    try {
-      assert.equal(
-        grid.activeCell.rowIndex,
-        2,
-        'rowIndex is position in originalData',
-      );
-      assert.equal(grid.activeCell.columnIndex, 2, 'columnIndex unchanged');
-      assert.equal(
-        grid.activeCell.viewRowIndex,
-        0,
-        'viewRowIndex is position in viewData',
-      );
-      assert.equal(grid.activeCell.viewColumnIndex, 1, 'viewColumnIndex = 1');
-    } catch (error) {
-      return done(error);
-    }
-
-    done();
   });
 
   it('Property `viewData` should be deeply equal to source data, if not filtered', function () {

--- a/test/sorters.js
+++ b/test/sorters.js
@@ -16,7 +16,10 @@ export default function () {
     });
     grid.order('a', 'desc');
     done(
-      assertIf(grid.data[0].a !== 'd', 'expected to see sort by string desc'),
+      assertIf(
+        grid.viewData[0].a !== 'd',
+        'expected to see sort by string desc',
+      ),
     );
   });
   it('Should sort numbers', function (done) {
@@ -26,7 +29,9 @@ export default function () {
       schema: [{ name: 'a', type: 'number' }],
     });
     grid.order('a', 'desc');
-    done(assertIf(grid.data[0].a !== 5, 'expected to see sort by number desc'));
+    done(
+      assertIf(grid.viewData[0].a !== 5, 'expected to see sort by number desc'),
+    );
   });
   it('Should sort date', function (done) {
     var grid = g({
@@ -47,7 +52,7 @@ export default function () {
     grid.order('a', 'desc');
     done(
       assertIf(
-        grid.data[0].a !== 1503307136397,
+        grid.viewData[0].a !== 1503307136397,
         'expected to see sort by date desc',
       ),
     );
@@ -94,7 +99,10 @@ export default function () {
     });
     grid.order('a', 'desc');
     done(
-      assertIf(grid.data[0].a !== '2', 'expected to see sort by string desc'),
+      assertIf(
+        grid.viewData[0].a !== '2',
+        'expected to see sort by string desc',
+      ),
     );
   });
   it('Should preserve current sort order, effectively allowing sort on multiple columns', function (done) {
@@ -114,7 +122,7 @@ export default function () {
     grid.order('b', 'asc');
     done(
       assertIf(
-        grid.data[0].a !== 'b',
+        grid.viewData[0].a !== 'b',
         'expected to see sort by a desc then b asc',
       ),
     );
@@ -149,12 +157,14 @@ export default function () {
           e.direction,
         ) ||
         assertIf(
-          grid.data[0].a !== 'a',
+          grid.viewData[0].a !== 'a',
           'expected data to not be sorted in event',
         );
     });
     grid.order('a', 'desc');
-    done(err || assertIf(grid.data[0].a !== 'c', 'expected data to be sorted'));
+    done(
+      err || assertIf(grid.viewData[0].a !== 'c', 'expected data to be sorted'),
+    );
   });
   it('Should not sort when beforesortcolumn prevents default', function (done) {
     var grid = g({
@@ -166,7 +176,9 @@ export default function () {
       e.preventDefault();
     });
     grid.order('a', 'desc');
-    done(assertIf(grid.data[0].a !== 'a', 'expected no change in sort order'));
+    done(
+      assertIf(grid.viewData[0].a !== 'a', 'expected no change in sort order'),
+    );
   });
   it('Should raise sortcolumn event after sort', function (done) {
     var grid = g({
@@ -182,7 +194,7 @@ export default function () {
             'direction should be "desc" but was "%s"',
             e.direction,
           ) ||
-          assertIf(grid.data[0].a !== 'c', 'expected data to be sorted'),
+          assertIf(grid.viewData[0].a !== 'c', 'expected data to be sorted'),
       );
     });
     grid.order('a', 'desc');
@@ -239,7 +251,10 @@ export default function () {
     });
     grid.order('a', 'desc');
     done(
-      assertIf(grid.data[0].a !== 'cd', 'expected schema sorter to be used'),
+      assertIf(
+        grid.viewData[0].a !== 'cd',
+        'expected schema sorter to be used',
+      ),
     );
   });
   it('Should reapply current sort after data set', function (done) {
@@ -264,7 +279,7 @@ export default function () {
     ];
     done(
       assertIf(
-        grid.data[0].a !== 'b',
+        grid.viewData[0].a !== 'b',
         'expected to see sort by a desc then b asc',
       ),
     );
@@ -286,7 +301,7 @@ export default function () {
     grid.setFilter('b', 'a');
     done(
       assertIf(
-        grid.data[0].a !== 'b',
+        grid.viewData[0].a !== 'b',
         'expected to see sort by a desc then b asc',
       ),
     );

--- a/test/web-component.js
+++ b/test/web-component.js
@@ -10,7 +10,10 @@ export default function () {
       component: true,
     });
     grid.style.activeCellBackgroundColor = c.b;
-    assertIf(grid.data.length !== 3, 'Expected to see data in the interface.');
+    assertIf(
+      grid.viewData.length !== 3,
+      'Expected to see data in the interface.',
+    );
     assertPxColor(grid, 80, 32, c.b, done);
   });
   it('Should create a web component and set a hyphenated style', function (done) {
@@ -20,7 +23,10 @@ export default function () {
       component: true,
     });
     grid.style['active-cell-background-color'] = c.b;
-    assertIf(grid.data.length !== 3, 'Expected to see data in the interface.');
+    assertIf(
+      grid.viewData.length !== 3,
+      'Expected to see data in the interface.',
+    );
     assertPxColor(grid, 80, 32, c.b, done);
   });
   it('Should create a web component and set a hyphenated style with a custom prefix', function (done) {
@@ -30,7 +36,10 @@ export default function () {
       component: true,
     });
     grid.style['--cdg-active-cell-background-color'] = c.b;
-    assertIf(grid.data.length !== 3, 'Expected to see data in the interface.');
+    assertIf(
+      grid.viewData.length !== 3,
+      'Expected to see data in the interface.',
+    );
     assertPxColor(grid, 80, 32, c.b, done);
   });
   it('Should create a web component and set a schema', function (done) {
@@ -41,7 +50,10 @@ export default function () {
     });
     grid.style.gridBackgroundColor = c.b;
     grid.schema = [{ name: 'a', width: 30 }];
-    assertIf(grid.data.length !== 1, 'Expected to see data in the interface.');
+    assertIf(
+      grid.viewData.length !== 1,
+      'Expected to see data in the interface.',
+    );
     assertPxColor(grid, 80, 32, c.b, done);
   });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,10 @@ const developmentConfig = {
   mode: 'development',
   devtool: 'source-map',
   devServer: {
-    contentBase: './dist',
+    contentBase: [
+      path.join(__dirname, 'dist'),
+      path.join(__dirname, 'tutorials'),
+    ],
   },
 
   output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,13 +2,11 @@ const path = require('path');
 
 const productionConfig = {
   mode: 'production',
-  
+
   entry: './lib/main.js',
 
   module: {
-    rules: [
-      { test: /\.js$/, exclude: /node_modules/, use: "babel-loader" }
-    ]
+    rules: [{ test: /\.js$/, exclude: /node_modules/, use: 'babel-loader' }],
   },
 
   output: {
@@ -16,16 +14,18 @@ const productionConfig = {
     library: 'canvasDatagrid',
     libraryTarget: 'umd',
     libraryExport: 'default',
-    filename: 'canvas-datagrid.js'
+    filename: 'canvas-datagrid.js',
   },
-
 };
 
 const developmentConfig = {
   ...productionConfig,
-  
+
   mode: 'development',
   devtool: 'source-map',
+  devServer: {
+    contentBase: './dist',
+  },
 
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -33,7 +33,7 @@ const developmentConfig = {
     libraryTarget: 'umd',
     libraryExport: 'default',
     filename: 'canvas-datagrid.debug.js',
-    sourceMapFilename: 'canvas-datagrid.debug.map'
+    sourceMapFilename: 'canvas-datagrid.debug.map',
   },
 };
 


### PR DESCRIPTION
Provides a (possible) solution for #241, by making a distinction between the data that is currently being rendered (due to filtering/sorting), and the entire set of data available to the grid.

- Adds a (internally and externally accessible) property `viewData`, which refers to the _currently rendered data_.
- Adds `boundData` which refers to `self.originalData`. Not sure if we should keep this, or just provide access to `originalData` directly.
- Changes to `cell` object (as created in `drawCell` and emitted in events), see below.

#### Changes to `cell`

The `drawCell` function constructs a cell object with a number of properties, such as style, value, but also location data. This PR:

- Keeps `rowIndex` and `columnIndex` unchanged for now, although I think we'd want to deprecate those properties to avoid confusion.
- Adds `viewRowIndex` and `viewColumnIndex` to a cell's draw to refer to the position of the cell _as it is rendered_, i.e. after filtering and sorting the data.
- Adds `boundRowIndex` and `boundColumnIndex`, which is the position in `self.originalData`, i.e. _before_ the data is sorted or filtered.


#### How it works, sort of

The new method `refresh` makes a shallow copy of `originalData`, and maps each row to a `(row, rowIndex)` tuple. It then applies filters and sorts the data in this array. After unpacking the tuples (remapping it to just rows), the resulting array is then basically `viewData`; the original row indexes (which are no longer in order due to filtering/sorting) are then added to a `Map`, which maps `viewRowIndex` to `boundRowIndex`, so we can determine the original row. This is used in `getBoundRowIndexFromViewRowIndex`