### PR TITLE
Fix missing text where value has multiple '-'

### DIFF
--- a/lib/draw.js
+++ b/lib/draw.js
@@ -362,9 +362,10 @@ export default function (self) {
     elWidth = self.ctx.measureText(' ' + et).width;
     for (x = 0; x < words.length; x += 1) {
       word = words[x];
-      var measure = self.ctx.measureText(word + splitChar);
+      var curSplitChar = word[word.length - 1] === '-' ? '' : splitChar;
+      var measure = self.ctx.measureText(word + curSplitChar);
       if (line.width + measure.width + elWidth < cell.paddedWidth) {
-        line.value += word + splitChar;
+        line.value += word + curSplitChar;
         line.width += measure.width;
         continue;
       }
@@ -373,13 +374,17 @@ export default function (self) {
       // then back up and re-read new split set
       // this behavior seems right, it might not be
       if (/\w-\w/.test(word) && cell.paddedWidth < measure.width) {
-        words.splice(x, 1, word.split('-')[0] + '-', word.split('-')[1]);
+        var arr = word.split('-');
+        arr = arr.map((item, index) => {
+          return index === arr.length - 1 ? item : item + '-';
+        });
+        words.splice(x, 1, ...arr);
         x -= 1;
         continue;
       }
       line = {
         width: measure.width,
-        value: word + splitChar,
+        value: word + curSplitChar,
       };
       if (x === 0) {
         lines = [];


### PR DESCRIPTION
where row value has multiple '-', the cell show only before '-';
![image](https://user-images.githubusercontent.com/18085334/129185565-d98b71d6-e45e-482a-a16f-d85d1963953f.png)
![image](https://user-images.githubusercontent.com/18085334/129185601-2515bc1e-5d6b-4a09-97cf-77bf25010b29.png)
