### PR TITLE
Fix autoscroll issue when selecting a cell on top or bottom row

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -19,6 +19,8 @@ export default function (self) {
       ['autoGenerateSchema', false],
       ['autoResizeColumns', false],
       ['autoResizeRows', false],
+      ['autoScrollOnMousemove', false],
+      ['autoScrollMargin', 5],
       ['blanksText', '(Blanks)'],
       ['borderDragBehavior', 'none'],
       ['borderResizeZone', 10],

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -25,6 +25,8 @@
  * @param {boolean} [args.editable=true] - When true, cells can be edited. When false, grid is read only to the user.
  * @param {string} [args.borderDragBehavior='none'] - Can be set to 'resize', 'move', or 'none'.  If set to 'move', `allowMovingSelection` should also be set true.  If set to 'resize', `allowRowResizeFromCell` and/or `allowColumnResizeFromCell` should be set true.
  * @param {boolean} [args.autoGenerateSchema=false] - When true, every time data is set the schema will be automatically generated from the data overwriting any existing schema.
+ * @param {boolean} [args.autoScrollOnMousemove=false] - Only trigger auto scrolling when mouse moves in horizontal or vertical direction.
+ * @param {number} [args.autoScrollMargin=5] - Number of pixels of mouse movement to trigger auto scroll.
  * @param {boolean} [args.allowFreezingRows=false] - When true, the UI provides a drag-able cutter to freeze rows.
  * @param {boolean} [args.allowFreezingColumns=false] - When true, the UI provides a drag-able cutter to freeze columns.
  * @param {boolean} [args.allowColumnReordering=true] - When true columns can be reordered.
@@ -54,6 +56,7 @@
  * @param {boolean} [args.showRowNumberGaps=true] - When true, gaps between row numbers due to filtering are shown in the row headers using a colored bar.
  * @param {boolean} [args.showRowHeaders=true] - When true, row headers are shown.
  * @param {number} [args.reorderDeadZone=3] - Number of pixels needed to move before column reordering occurs.
+ * @param {number} [args.selectionScrollZone=20] - Number of pixels to auto scroll in in horizontal or vertical direction.
  * @param {boolean} [args.showClearSettingsOption=true] - Show an option on the context menu to clear saved settings.
  * @param {string} [args.clearSettingsOptionText='Clear saved settings'] - Text that appears on the clear settings option.
  * @param {string} [args.showOrderByOptionTextDesc='Order by %s ascending'] - Text that appears on the order by descending option.

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -665,7 +665,7 @@ export default function (self) {
     self.eventParent.addEventListener('mousedown', self.mousedown, false);
     self.eventParent.addEventListener('dblclick', self.dblclick, false);
     self.eventParent.addEventListener('click', self.click, false);
-    self.eventParent.addEventListener('mousemove', self.mousemove);
+    document.body.addEventListener('mousemove', self.mousemove);
     self[self.isChildGrid ? 'parentGrid' : 'eventParent'].addEventListener(
       'wheel',
       self.scrollWheel,

--- a/lib/events.js
+++ b/lib/events.js
@@ -554,7 +554,7 @@ export default function (self) {
             self.selectArea(sBounds, true);
           }
         }
-        self.autoScrollZone(e, x, y, ctrl);
+        if (self.rowBoundaryCrossed) self.autoScrollZone(e, x, y, ctrl);
       }
     }
     self.cellBoundaryCrossed = false;

--- a/lib/events.js
+++ b/lib/events.js
@@ -467,8 +467,8 @@ export default function (self) {
       }
       if ((self.selecting || self.reorderObject) && cell.context === 'cell') {
         delta = {
-          x: self.dragStart.x - x,
-          y: self.dragStart.y - y,
+          x: Math.abs(self.dragStart.x - x),
+          y: Math.abs(self.dragStart.y - y),
         };
         if (self.dragStartObject.columnIndex !== -1 && e.shiftKey) {
           self.dragStartObject = {
@@ -555,14 +555,15 @@ export default function (self) {
           }
         }
 
-        // TODO: Make margin for movement configurable
-        // TODO: Make scrolling behaviour configurable
+        if (self.attributes.autoScrollOnMousemove) {
+          var movedVertically = delta.y > self.attributes.autoScrollMargin;
+          var movedHorizontally = delta.x > self.attributes.autoScrollMargin;
 
-        var movedVertically = delta.y < -5 || delta.y > 5;
-        var movedHorizontally = delta.x < -5 || delta.x > 5;
-
-        if (movedVertically) self.autoScrollZone(e, -1, y, ctrl);
-        if (movedHorizontally) self.autoScrollZone(e, x, -1, ctrl);
+          if (movedVertically) self.autoScrollZone(e, -1, y, ctrl);
+          if (movedHorizontally) self.autoScrollZone(e, x, -1, ctrl);
+        } else {
+          self.autoScrollZone(e, x, y, ctrl);
+        }
       }
     }
     self.cellBoundaryCrossed = false;

--- a/lib/events.js
+++ b/lib/events.js
@@ -467,8 +467,8 @@ export default function (self) {
       }
       if ((self.selecting || self.reorderObject) && cell.context === 'cell') {
         delta = {
-          x: Math.abs(self.dragStart.x - x),
-          y: Math.abs(self.dragStart.y - y),
+          x: self.dragStart.x - x,
+          y: self.dragStart.y - y,
         };
         if (self.dragStartObject.columnIndex !== -1 && e.shiftKey) {
           self.dragStartObject = {
@@ -554,7 +554,15 @@ export default function (self) {
             self.selectArea(sBounds, true);
           }
         }
-        if (self.rowBoundaryCrossed) self.autoScrollZone(e, x, y, ctrl);
+
+        // TODO: Make margin for movement configurable
+        // TODO: Make scrolling behaviour configurable
+
+        var movedVertically = delta.y < -5 || delta.y > 5;
+        var movedHorizontally = delta.x < -5 || delta.x > 5;
+
+        if (movedVertically) self.autoScrollZone(e, -1, y, ctrl);
+        if (movedHorizontally) self.autoScrollZone(e, x, -1, ctrl);
       }
     }
     self.cellBoundaryCrossed = false;

--- a/lib/events.js
+++ b/lib/events.js
@@ -446,15 +446,9 @@ export default function (self) {
       });
     }
     self.currentCell = cell;
-    if (!self.hasFocus) {
-      return;
-    }
+
     self.hovers = {};
-    if (
-      !self.draggingItem &&
-      cell &&
-      self.scrollModes.indexOf(cell.context) === -1
-    ) {
+    if (!self.draggingItem && cell) {
       self.dragItem = cell;
       self.dragMode = cell.dragContext;
       self.cursor = cell.context;
@@ -465,7 +459,7 @@ export default function (self) {
           columnIndex: cell.columnIndex,
         };
       }
-      if ((self.selecting || self.reorderObject) && cell.context === 'cell') {
+      if (self.selecting || self.reorderObject) {
         delta = {
           x: Math.abs(self.dragStart.x - x),
           y: Math.abs(self.dragStart.y - y),
@@ -559,8 +553,12 @@ export default function (self) {
           var movedVertically = delta.y > self.attributes.autoScrollMargin;
           var movedHorizontally = delta.x > self.attributes.autoScrollMargin;
 
-          if (movedVertically) self.autoScrollZone(e, -1, y, ctrl);
-          if (movedHorizontally) self.autoScrollZone(e, x, -1, ctrl);
+          if (movedVertically && !movedHorizontally)
+            self.autoScrollZone(e, -1, y, ctrl);
+          else if (movedHorizontally && !movedVertically)
+            self.autoScrollZone(e, x, -1, ctrl);
+          else if (movedHorizontally && movedVertically)
+            self.autoScrollZone(e, x, y, ctrl);
         } else {
           self.autoScrollZone(e, x, y, ctrl);
         }

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -387,10 +387,7 @@ export default function (self, ctor) {
       rowHeaderCellWidth = self.getRowHeaderCellWidth(),
       columnHeaderCellHeight = self.getColumnHeaderCellHeight();
     if (x !== -1) {
-      if (
-        x > self.width - self.attributes.selectionScrollZone &&
-        x < self.width
-      ) {
+      if (x > self.width - self.attributes.selectionScrollZone) {
         self.scrollBox.scrollLeft += self.attributes.selectionScrollIncrement;
         setTimer = true;
       }
@@ -400,10 +397,7 @@ export default function (self, ctor) {
       }
     }
     if (y !== -1) {
-      if (
-        y > self.height - self.attributes.selectionScrollZone &&
-        y < self.height
-      ) {
+      if (y > self.height - self.attributes.selectionScrollZone) {
         self.scrollBox.scrollTop += self.attributes.selectionScrollIncrement;
         setTimer = true;
       }

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -386,7 +386,7 @@ export default function (self, ctor) {
     var setTimer,
       rowHeaderCellWidth = self.getRowHeaderCellWidth(),
       columnHeaderCellHeight = self.getColumnHeaderCellHeight();
-    if (y !== -1) {
+    if (x !== -1) {
       if (
         x > self.width - self.attributes.selectionScrollZone &&
         x < self.width

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -491,17 +491,19 @@ export default function () {
       mousedown(grid.canvas, 10, 29);
       mousemove(grid.canvas, 10, 90, grid.canvas);
       mousemove(document.body, 10, 90, grid.canvas);
-      assertPxColor(grid, 10, 98, c.b, function (err) {
-        if (err) {
-          return done(err);
-        }
-        assertPxColor(grid, 10, 86, c.fu, function (err) {
+      setTimeout(function () {
+        assertPxColor(grid, 10, 98, c.b, function (err) {
           if (err) {
             return done(err);
           }
-          assertPxColor(grid, 30, 91, c.y, done);
+          assertPxColor(grid, 10, 86, c.fu, function (err) {
+            if (err) {
+              return done(err);
+            }
+            assertPxColor(grid, 30, 91, c.y, done);
+          });
         });
-      });
+      }, 10);
       grid.draw();
     }, 10);
   });

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -50,9 +50,8 @@ export default function () {
     });
     setTimeout(function () {
       grid.focus();
-      mousemove(grid.canvas, 10, 48);
+      mousemove(document.body, 10, 48, grid.canvas);
       mousedown(grid.canvas, 10, 48);
-      mousemove(grid.canvas, 10, 160, grid.canvas);
       mousemove(document.body, 10, 160, grid.canvas);
       mouseup(document.body, 10, 160, grid.canvas);
 
@@ -352,9 +351,8 @@ export default function () {
     setTimeout(function () {
       grid.focus();
       marker(grid, 67, 10);
-      mousemove(grid.canvas, 67, 10);
+      mousemove(document.body, 67, 10, grid.canvas);
       mousedown(grid.canvas, 67, 10);
-      mousemove(grid.canvas, 140, 10, grid.canvas);
       mousemove(document.body, 140, 10, grid.canvas);
       mouseup(document.body, 140, 10, grid.canvas);
       grid.draw();
@@ -452,9 +450,8 @@ export default function () {
     setTimeout(function () {
       grid.focus();
       marker(grid, 10, 32);
-      mousemove(grid.canvas, 10, 29);
+      mousemove(document.body, 10, 29, grid.canvas);
       mousedown(grid.canvas, 10, 29);
-      mousemove(grid.canvas, 10, 90, grid.canvas);
       mousemove(document.body, 10, 90, grid.canvas);
       mouseup(document.body, 10, 90, grid.canvas);
       grid.draw();
@@ -487,9 +484,8 @@ export default function () {
     });
     setTimeout(function () {
       grid.focus();
-      mousemove(grid.canvas, 10, 29);
+      mousemove(document.body, 10, 29, grid.canvas);
       mousedown(grid.canvas, 10, 29);
-      mousemove(grid.canvas, 10, 90, grid.canvas);
       mousemove(document.body, 10, 90, grid.canvas);
       setTimeout(function () {
         assertPxColor(grid, 10, 98, c.b, function (err) {

--- a/test/drawing.js
+++ b/test/drawing.js
@@ -19,10 +19,11 @@ export default function () {
         cellSelectedBackgroundColor: c.b,
       },
     });
-    mousemove(grid.canvas, 45, 37);
+
+    mousemove(document.body, 45, 37, grid.canvas);
     mousedown(grid.canvas, 45, 37);
     mouseup(grid.canvas, 45, 37);
-    mousemove(grid.canvas, 45, 37);
+    mousemove(document.body, 45, 37, grid.canvas);
     setTimeout(function () {
       assertPxColor(grid, 80, 37, c.b, done);
     }, 1);

--- a/test/editing.js
+++ b/test/editing.js
@@ -114,7 +114,7 @@ export default function () {
       test: this.test,
       data: [{ d: '' }],
     });
-    mousemove(grid.canvas, 65, 37);
+    mousemove(document.body, 65, 37, grid.canvas);
     mousedown(grid.canvas, 65, 37);
     mouseup(grid.canvas, 65, 37);
     mousedown(grid.canvas, 65, 37);

--- a/test/public-interface.js
+++ b/test/public-interface.js
@@ -153,9 +153,9 @@ export default function () {
       test: this.test,
       data: [{ d: '123456', e: '123456' }],
     });
-    mousemove(grid.canvas, 45, 37);
+    mousemove(document.body, 45, 37, grid.canvas);
     mousedown(grid.canvas, 45, 37);
-    mouseup(grid.canvas, 45, 37);
+    mouseup(document.body, 45, 37, grid.canvas);
     done(
       assertIf(
         grid.currentCell.rowIndex !== 0,

--- a/test/resize.js
+++ b/test/resize.js
@@ -23,9 +23,8 @@ export default function () {
       }
     });
     grid.focus();
-    mousemove(grid.canvas, 94, 10);
+    mousemove(document.body, 94, 10, grid.canvas);
     mousedown(grid.canvas, 94, 10);
-    mousemove(grid.canvas, 190, 10, grid.canvas);
     mousemove(document.body, 190, 10, grid.canvas);
     mouseup(document.body, 190, 10, grid.canvas);
     setTimeout(function () {
@@ -49,9 +48,8 @@ export default function () {
     });
     setTimeout(function () {
       grid.focus();
-      mousemove(grid.canvas, 94, 36);
+      mousemove(document.body, 94, 36, grid.canvas);
       mousedown(grid.canvas, 94, 36);
-      mousemove(grid.canvas, 190, 36, grid.canvas);
       mousemove(document.body, 190, 36, grid.canvas);
       mouseup(document.body, 190, 36, grid.canvas);
       assertPxColor(grid, 110, 36, c.b, done);
@@ -72,9 +70,8 @@ export default function () {
     });
     setTimeout(function () {
       grid.focus();
-      mousemove(grid.canvas, 10, 48);
+      mousemove(document.body, 10, 48, grid.canvas);
       mousedown(grid.canvas, 10, 48);
-      mousemove(grid.canvas, 10, 100, grid.canvas);
       mousemove(document.body, 10, 100, grid.canvas);
       mouseup(document.body, 10, 100, grid.canvas);
       assertPxColor(grid, 10, 90, c.b, done);
@@ -97,9 +94,8 @@ export default function () {
     });
     setTimeout(function () {
       grid.focus();
-      mousemove(grid.canvas, 40, 48);
+      mousemove(document.body, 40, 48, grid.canvas);
       mousedown(grid.canvas, 40, 48);
-      mousemove(grid.canvas, 40, 100, grid.canvas);
       mousemove(document.body, 40, 100, grid.canvas);
       mouseup(document.body, 40, 100, grid.canvas);
       assertPxColor(grid, 10, 90, c.b, done);

--- a/test/selections.js
+++ b/test/selections.js
@@ -375,9 +375,8 @@ export default function () {
     grid.style.cellBackgroundColor = c.fu;
     setTimeout(function () {
       grid.focus();
-      mousemove(grid.canvas, 67, 30);
+      mousemove(document.body, 67, 30, grid.canvas);
       mousedown(grid.canvas, 67, 30);
-      mousemove(grid.canvas, 320, 65, grid.canvas);
       mousemove(document.body, 320, 65, grid.canvas);
       mouseup(document.body, 320, 65, grid.canvas);
       mouseup(grid.canvas, 320, 65, grid.canvas);
@@ -417,15 +416,14 @@ export default function () {
     setTimeout(function () {
       var p = bb(grid.canvas);
       grid.focus();
-      mousemove(grid.canvas, 67, 30);
+      mousemove(document.body, 67, 30, grid.canvas);
       mousedown(grid.canvas, 67, 30);
-      mousemove(grid.canvas, 320, 65, grid.canvas);
       mousemove(document.body, 320, 65, grid.canvas);
       mouseup(document.body, 320, 65, grid.canvas);
       mouseup(grid.canvas, 320, 65, grid.canvas);
       click(grid.canvas, 320, 65);
       // ctrl click
-      de(grid.canvas, 'mousemove', {
+      de(document.body, 'mousemove', {
         clientX: 320 + p.left,
         clientY: 65 + p.top,
         ctrlKey: true,


### PR DESCRIPTION
Fix issue where selection of 1 or more cells on top or bottom row of the grid (once the grid has been scrolled down) adds addtional cells to the selection.

![selection-top-row-after-scroll](https://user-images.githubusercontent.com/101284/129738644-f989b7fa-15ab-4735-8272-043883548ca6.gif)

Steps to reproduce:
- scroll down in the grid (on a scrollable canvas)
- click a cell on the top row, click in the upper half of the cell
- notice the grid scrolling down 1 or 2 rows and increasing the selected area.

Changes proposed in this pull request: 

I've tracked the issue down to a call of [autoScrollZone](https://github.com/TonyGermaneri/canvas-datagrid/blob/7bb0e553075f5cddfb5e70f7b6f2b9b1de813a32/lib/events.js#L557) in the [mousemove](https://github.com/TonyGermaneri/canvas-datagrid/blob/7bb0e553075f5cddfb5e70f7b6f2b9b1de813a32/lib/events.js#L408) event handler. This method [updates](https://github.com/TonyGermaneri/canvas-datagrid/blob/7bb0e553075f5cddfb5e70f7b6f2b9b1de813a32/lib/intf.js#L414) [scrollBox.scrollTop](https://github.com/TonyGermaneri/canvas-datagrid/blob/7bb0e553075f5cddfb5e70f7b6f2b9b1de813a32/lib/intf.js#L1555) and causes the grid to auto scroll down a row and retrigger `mousemove` to select additional cells. 

I've made the call conditional on `self.rowBoundaryCrossed` being `false`. This seems to make sense as we don't want to scroll the grid if the mouse moves laterally along the same row (i.e. mouse button release was delayed or user intended to select multiple adjacent cells from the same row).

![selection-top-row-after-scroll-after-change](https://user-images.githubusercontent.com/101284/129751533-b274fcce-8f84-4cab-924b-dd0ab9176422.gif)

Other approaches:
- Use the `delta` variable to check that mouse didn't move; this is too brittle IMHO as the mouse can move very subtly between mouse button press and release)
- Use `self.cellBoundaryCrossed` to check that mouse cursor is till in same cell; this does not allow selection of multiple cells on the top or bottom row.

A workaround that seems to work for us is to set the the attribute `selectionScrollZone` to 0, this avoids the scroll triggered by `autoScrollZone`. 
