### PR TITLE
Fix paste in filter mode

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1544,7 +1544,12 @@ export default function (self) {
           newRowData[columnName] = cellData;
         }
 
-        self.originalData[realRowIndex] = newRowData;
+        self.originalData[self.boundRowIndexMap.get(realRowIndex)] = newRowData;
+        // Update view date here to avoid a full refresh of `viewData`.
+        // To stay in line with Excel and Google Sheet behaviour,
+        // don't perform a full refresh (and filter/sort results)
+        // as this would make any pasted values disappear and/or suddenly change position.
+        self.viewData[realRowIndex] = newRowData;
       }
       self.selections = selections;
     }
@@ -1567,10 +1572,6 @@ export default function (self) {
     self.dispatchEvent('afterpaste', {
       cells: affectedCells,
     });
-
-    // Because originalData has been updated, we must refresh
-    // viewData to ensure the new cell values are rendered
-    self.draw(true);
 
     return rows.length;
   };

--- a/lib/events.js
+++ b/lib/events.js
@@ -1556,7 +1556,11 @@ export default function (self) {
       if (rowIndex === undefined) return;
 
       row.forEach(function (columnIndex) {
-        affectedCells.push([rowIndex, columnIndex]);
+        affectedCells.push([
+          rowIndex,
+          columnIndex,
+          self.getVisibleCellByIndex(columnIndex, rowIndex),
+        ]);
       });
     });
 
@@ -1566,7 +1570,7 @@ export default function (self) {
 
     // Because originalData has been updated, we must refresh
     // viewData to ensure the new cell values are rendered
-    self.refresh();
+    self.draw(true);
 
     return rows.length;
   };


### PR DESCRIPTION
When pasting data into a grid that has active filters: 

- Updates of cells don't happen correctly
- Updated cells disappear from filter results if values no longer pass filter criteria; this leads to a confusing user experience as changed cells "all of a sudden" disappear (e.g. Excel and Google Sheets maintain changed values in the filter results).

![paste-when-filtered-before](https://user-images.githubusercontent.com/101284/130066177-3abbcc8a-ad02-4ae9-8d7f-5b09ed812471.gif)

Changes proposed in this pull request: 
- The `rowIndex` of changed cells is mapped to the `boundRowIndex` so changes apply to `originalData` correctly.
- Don't refresh the grid after a paste event.

The result after changes applied:  

![paste-when-filtered-after](https://user-images.githubusercontent.com/101284/130066753-116dd077-9e02-4b78-b488-2a2402706428.gif)

