### PR TITLE
Shrink keyboard selections

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1230,8 +1230,8 @@ export default function (self) {
     var i,
       ev,
       adjacentCells = self.getAdjacentCells(),
-      x = self.activeCell.columnIndex,
-      y = self.activeCell.rowIndex,
+      x = Math.max(self.activeCell.columnIndex, 0),
+      y = Math.max(self.activeCell.rowIndex, 0),
       ctrl = e.ctrlKey || e.metaKey,
       last = self.viewData.length - 1,
       s = self.getSchema(),
@@ -1324,9 +1324,52 @@ export default function (self) {
       'ArrowDown',
     ].includes(e.key);
 
+    // Shrinking and expanding selection using shift and arrow keys
     if (e.shiftKey && isArrowKey) {
-      self.selections[Math.max(y, 0)] = self.selections[Math.max(y, 0)] || [];
-      self.selections[Math.max(y, 0)].push(x);
+      const firstSelectedRowIndex = self.selections.findIndex((el) => !!el);
+      const firstSelectedRow = self.selections[firstSelectedRowIndex];
+      const firstSelectedColumnIndex = firstSelectedRow[0];
+      const lastSelectedColumn = firstSelectedRow[firstSelectedRow.length - 1];
+      const xAtLeftEdge = firstSelectedColumnIndex === 0;
+      const xAtRightEdge = x === cols;
+
+      if (firstSelectedRowIndex !== y) {
+        if (e.key === 'ArrowUp') {
+          if (y + 1 > firstSelectedRowIndex) {
+            self.selections.pop();
+          } else if (y < firstSelectedRowIndex) {
+            self.selections[y] = self.selections[y] || [];
+            self.selections[y].push(x);
+          }
+        }
+
+        if (e.key === 'ArrowDown') {
+          if (y > firstSelectedRowIndex && y === self.selections.length) {
+            self.selections[y] = self.selections[y] || [];
+            self.selections[y].push(x);
+          } else if (y > firstSelectedRowIndex) {
+            delete self.selections[y - 1];
+          }
+        }
+      }
+
+      for (const selection of self.selections) {
+        if (e.key === 'ArrowRight' && selection) {
+          if (x > lastSelectedColumn) {
+            selection.push(x);
+          } else if (x <= lastSelectedColumn && !xAtRightEdge) {
+            selection.shift();
+          }
+        }
+
+        if (e.key === 'ArrowLeft' && selection) {
+          if (x >= firstSelectedColumnIndex && !xAtLeftEdge) {
+            selection.pop();
+          } else if (x < firstSelectedColumnIndex) {
+            selection.unshift(x);
+          }
+        }
+      }
 
       self.selectionBounds = self.getSelectionBounds();
       self.selectArea(undefined, ctrl);

--- a/lib/events.js
+++ b/lib/events.js
@@ -1301,7 +1301,6 @@ export default function (self) {
       e.preventDefault();
       return self.beginEditAt(x, y, e);
     }
-
     if (x < 0 || Number.isNaN(x)) {
       x = adjacentCells.first;
     }
@@ -1330,26 +1329,30 @@ export default function (self) {
       const firstSelectedRow = self.selections[firstSelectedRowIndex];
       const firstSelectedColumnIndex = firstSelectedRow[0];
       const lastSelectedColumn = firstSelectedRow[firstSelectedRow.length - 1];
-      const xAtLeftEdge = firstSelectedColumnIndex === 0;
-      const xAtRightEdge = x === cols;
+      const yAtTop = y === 0;
+      const yAtBottom = y === last;
+      const xAtLeft = x === 0;
+      const xAtRight = x === cols;
 
-      if (firstSelectedRowIndex !== y) {
-        if (e.key === 'ArrowUp') {
-          if (y + 1 > firstSelectedRowIndex) {
-            self.selections.pop();
-          } else if (y < firstSelectedRowIndex) {
-            self.selections[y] = self.selections[y] || [];
-            self.selections[y].push(x);
-          }
+      if (e.key === 'ArrowUp') {
+        if (y + 1 > firstSelectedRowIndex && !yAtTop) {
+          self.selections.pop();
+        } else if (y < firstSelectedRowIndex) {
+          self.selections[y] = self.selections[y] || [];
+          self.selections[y].push(x);
+        } else if (yAtTop && self.activeCell.rowIndex !== 0) {
+          self.selections.pop();
         }
+      }
 
-        if (e.key === 'ArrowDown') {
-          if (y > firstSelectedRowIndex && y === self.selections.length) {
-            self.selections[y] = self.selections[y] || [];
-            self.selections[y].push(x);
-          } else if (y > firstSelectedRowIndex) {
-            delete self.selections[y - 1];
-          }
+      if (e.key === 'ArrowDown') {
+        if (y > firstSelectedRowIndex && y === self.selections.length) {
+          self.selections[y] = self.selections[y] || [];
+          self.selections[y].push(x);
+        } else if (y >= firstSelectedRowIndex && !yAtBottom) {
+          delete self.selections[y - 1];
+        } else if (yAtBottom && self.activeCell.rowIndex !== last) {
+          delete self.selections[y - 1];
         }
       }
 
@@ -1357,16 +1360,20 @@ export default function (self) {
         if (e.key === 'ArrowRight' && selection) {
           if (x > lastSelectedColumn) {
             selection.push(x);
-          } else if (x <= lastSelectedColumn && !xAtRightEdge) {
+          } else if (x <= lastSelectedColumn && !xAtRight) {
+            selection.shift();
+          } else if (xAtRight && self.activeCell.columnIndex !== cols) {
             selection.shift();
           }
         }
 
         if (e.key === 'ArrowLeft' && selection) {
-          if (x >= firstSelectedColumnIndex && !xAtLeftEdge) {
-            selection.pop();
-          } else if (x < firstSelectedColumnIndex) {
+          if (x < firstSelectedColumnIndex) {
             selection.unshift(x);
+          } else if (x >= firstSelectedColumnIndex && !xAtLeft) {
+            selection.pop();
+          } else if (xAtLeft && self.activeCell.columnIndex !== 0) {
+            selection.pop();
           }
         }
       }

--- a/test/key-navigation.js
+++ b/test/key-navigation.js
@@ -195,6 +195,114 @@ export default function () {
       ),
     );
   });
+  it('shrink selection when pressing Shift and Arrow-up ', function (done) {
+    var grid = g({
+      test: this.test,
+      data: smallData(),
+    });
+
+    grid.focus();
+    grid.selectArea({
+      top: 1,
+      left: 1,
+      bottom: 2,
+      right: 2,
+    });
+
+    grid.setActiveCell(2, 2); // set to lower right corner of selection
+
+    var ev = new Event('keydown');
+    ev.shiftKey = true;
+    ev.key = 'ArrowUp';
+    grid.controlInput.dispatchEvent(ev);
+
+    var ev = new Event('keydown');
+    ev.shiftKey = true;
+    ev.key = 'ArrowLeft';
+    grid.controlInput.dispatchEvent(ev);
+
+    done(
+      assertIf(
+        grid.selectionBounds.top !== 1 ||
+          grid.selectionBounds.left !== 1 ||
+          grid.selectionBounds.bottom !== 1 ||
+          grid.selectionBounds.right !== 1,
+        'Expected the selection to shrink by a row and column.',
+      ),
+    );
+  });
+  it('shrink selection to top/left corner when pressing Shift and Arrow-up/left ', function (done) {
+    var grid = g({
+      test: this.test,
+      data: smallData(),
+    });
+
+    grid.focus();
+    grid.selectArea({
+      top: 0,
+      left: 0,
+      bottom: 1,
+      right: 1,
+    });
+
+    grid.setActiveCell(1, 1); // set to lower right corner of selection
+
+    var ev = new Event('keydown');
+    ev.shiftKey = true;
+    ev.key = 'ArrowUp';
+    grid.controlInput.dispatchEvent(ev);
+
+    var ev = new Event('keydown');
+    ev.shiftKey = true;
+    ev.key = 'ArrowLeft';
+    grid.controlInput.dispatchEvent(ev);
+
+    done(
+      assertIf(
+        grid.selectionBounds.top !== 0 ||
+          grid.selectionBounds.left !== 0 ||
+          grid.selectionBounds.bottom !== 0 ||
+          grid.selectionBounds.right !== 0,
+        'Expected the selection to shrink to 1 cell.',
+      ),
+    );
+  });
+  it('shrink selection to bottom/right corner when pressing Shift and Arrow-down/right', function (done) {
+    var grid = g({
+      test: this.test,
+      data: smallData(),
+    });
+
+    grid.focus();
+    grid.selectArea({
+      top: 1,
+      left: 1,
+      bottom: 2,
+      right: 2,
+    });
+
+    grid.setActiveCell(1, 1); // set to upper left corner of selection
+
+    var ev = new Event('keydown');
+    ev.shiftKey = true;
+    ev.key = 'ArrowDown';
+    grid.controlInput.dispatchEvent(ev);
+
+    var ev = new Event('keydown');
+    ev.shiftKey = true;
+    ev.key = 'ArrowRight';
+    grid.controlInput.dispatchEvent(ev);
+
+    done(
+      assertIf(
+        grid.selectionBounds.top !== 2 ||
+          grid.selectionBounds.left !== 2 ||
+          grid.selectionBounds.bottom !== 2 ||
+          grid.selectionBounds.right !== 2,
+        'Expected the selection to shrink to 1 cell.',
+      ),
+    );
+  });
   it('Shift tab should behave like left arrow', function (done) {
     var ev,
       grid = g({


### PR DESCRIPTION
When using keyboard navigation to select cells the selection only grows when additional rows or columns are added. 

![CleanShot 2021-09-29 at 14 18 50](https://user-images.githubusercontent.com/101284/135267661-3b8364cb-c178-4ab8-bcf6-00359bfe1c8c.gif)

This is not in line with Excel/Google sheets behaviour and provides for a sub-optimal user-experience.

This PR changes the selection logic to allow for selections to be more flexible so that they can shrink if arrow keys are moved back:

![CleanShot 2021-09-29 at 14 31 20](https://user-images.githubusercontent.com/101284/135268861-84e0a37e-be30-40c3-b11d-8aa5055539ff.gif)


