### PR TITLE
Optionally allow keyboard interaction when mouse cursor is not inside the grid

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -42,6 +42,7 @@ export default function (self) {
       ['globalRowResize', false],
       ['hideColumnText', 'Hide %s'],
       ['hoverMode', 'cell'],
+      ['keepFocusOnMouseOut', false],
       ['maxAutoCompleteItems', 200],
       ['multiLine', false],
       ['name', ''],

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -41,6 +41,7 @@
  * @param {number} [args.pageUpDownOverlap=1] - Amount of rows to overlap when pageup/pagedown is used.
  * @param {boolean} [args.persistantSelectionMode=false] - When true, selections will behave as if the command/control key is held down at all times. Conflicts with singleSelectionMode.
  * @param {boolean} [args.singleSelectionMode=false] - When true, selections will ignore the command/control key. Conflicts with persistantSelectionMode.
+ * @param {boolean} [args.keepFocusOnMouseOut=false] - When true, grid will continue to handle keydown events when mouse is outside of the grid.
  * @param {string} [args.selectionMode='cell'] - Can be 'cell', or 'row'.  This setting dictates what will be selected when the user clicks a cell.  The cell, or the entire row respectively.
  * @param {string} [args.hoverMode='cell'] - Can be 'cell', or 'row'. This setting dictates whether to highlight either the individual cell, or the entire row when hovering over a cell.
  * @param {boolean} [args.autoResizeColumns=false] - When true, all columns will be automatically resized to fit the data in them. Warning! Expensive for large (&gt;100k ~2 seconds) datasets.

--- a/lib/events.js
+++ b/lib/events.js
@@ -1246,7 +1246,7 @@ export default function (self) {
       return;
     }
 
-    if (!self.hasFocus) {
+    if (!self.attributes.keepFocusOnMouseOut && !self.hasFocus) {
       return;
     }
 


### PR DESCRIPTION
When mouse cursor moves outside of the grid the grid loses focus (`grid.hasFocus` set to `false`) disabling keyboard interaction.

This PR is a small usability tweak to allow keyboard interaction even when mouse is not hovering over the grid. Focus can also be set programmatically (`grid.focus`) to allow user input irrespective of mouse cursor location.