### PR TITLE
Emit affected cells in cut event

### DIFF
--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1679,9 +1679,34 @@ export default function (self) {
   };
   self.cut = function (e) {
     self.copy(e);
-    self.forEachSelectedCell(function (data, index, colName) {
-      data[index][colName] = '';
-    });
+    const schema = self.getSchema();
+
+    var affectedCells = [];
+    for (const [rowIndex, row] of self.selections.entries()) {
+      if (!row) continue;
+
+      const boundRowIndex = self.getBoundRowIndexFromViewRowIndex(rowIndex);
+
+      for (const columnIndex of row) {
+        const boundColumnIndex = self.getBoundColumnIndexFromViewColumnIndex(
+          columnIndex,
+        );
+        const colName = schema[boundColumnIndex].name;
+
+        self.viewData[rowIndex][colName] = '';
+
+        affectedCells.push([
+          rowIndex,
+          columnIndex,
+          boundRowIndex,
+          boundColumnIndex,
+        ]);
+      }
+    }
+
+    if (self.dispatchEvent('cut', { NativeEvent: e, cells: affectedCells })) {
+      return;
+    }
   };
   self.copy = function (e) {
     if (self.dispatchEvent('copy', { NativeEvent: e })) {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -801,6 +801,7 @@ export default function (self, ctor) {
     self.intf.clearPxColorAssertions = self.clearPxColorAssertions;
     self.intf.integerToAlpha = self.integerToAlpha;
     self.intf.copy = self.copy;
+    self.intf.cut = self.cut;
     self.intf.paste = self.paste;
     self.intf.setStyleProperty = self.setStyleProperty;
     Object.defineProperty(self.intf, 'defaults', {

--- a/test/editing.js
+++ b/test/editing.js
@@ -526,4 +526,31 @@ export default function () {
     document.body.lastChild.dispatchEvent(ev);
     grid.endEdit();
   });
+  describe('cut', function () {
+    it('fires a cut event', function (done) {
+      var grid = g({
+        test: this.test,
+        data: [{ 'Column A': 'Original value' }],
+      });
+
+      grid.focus();
+      grid.setActiveCell(0, 0);
+      grid.selectArea({ top: 0, left: 0, bottom: 0, right: 0 });
+
+      grid.addEventListener('cut', function (event) {
+        try {
+          doAssert(!!event.cells, 'event has cells property');
+          doAssert(event.cells.length === 1, 'one row has been pasted ');
+          doAssert(event.cells[0][0] === 0, 'pasted column == 0');
+          doAssert(event.cells[0][2] === 0, 'pasted bound column == 0');
+        } catch (error) {
+          done(error);
+        }
+
+        done();
+      });
+
+      grid.cut({});
+    });
+  });
 }


### PR DESCRIPTION
The `cut` event does not emit affected cells. 

This PR adds affected cells to `cut` event data.