### PR TITLE
fix sort

### DIFF
--- a/lib/draw.js
+++ b/lib/draw.js
@@ -122,15 +122,15 @@ export default function (self) {
     x = x + ml;
     y = y + mt;
     if (self.orderDirection === 'asc') {
-      self.ctx.moveTo(x, y);
-      self.ctx.lineTo(x + aw, y);
-      self.ctx.lineTo(x + aw * 0.5, y + ah);
-      self.ctx.moveTo(x, y);
-    } else {
       self.ctx.lineTo(x, y + ah);
       self.ctx.lineTo(x + aw, y + ah);
       self.ctx.lineTo(x + aw * 0.5, y);
       self.ctx.lineTo(x, y + ah);
+    } else {
+      self.ctx.moveTo(x, y);
+      self.ctx.lineTo(x + aw, y);
+      self.ctx.lineTo(x + aw * 0.5, y + ah);
+      self.ctx.moveTo(x, y);
     }
     self.ctx.stroke();
     self.ctx.fill();

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1080,7 +1080,6 @@ export default function (self, ctor) {
         value = 'asc';
       }
       self.orderDirection = value;
-      self.order(self.orderBy, self.orderDirection);
     },
   });
   Object.defineProperty(self.intf, 'orderBy', {
@@ -1096,7 +1095,6 @@ export default function (self, ctor) {
         throw new Error('Cannot sort by unknown column name.');
       }
       self.orderBy = value;
-      self.order(self.orderBy, self.orderDirection);
     },
   });
   if (self.isComponent) {

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -1367,22 +1367,18 @@ export default function (self) {
   self.sorters.string = function (columnName, direction) {
     var asc = direction === 'asc';
     return function (a, b) {
-      if (a[columnName] === undefined || a[columnName] === null) {
-        return 1;
-      }
-      if (b[columnName] === undefined || b[columnName] === null) {
-        return 0;
-      }
+      const aValue = a[columnName] || '';
+      const bValue = b[columnName] || '';
       if (asc) {
-        if (!a[columnName].localeCompare) {
+        if (!aValue.localeCompare) {
           return 1;
         }
-        return a[columnName].localeCompare(b[columnName]);
+        return aValue.localeCompare(bValue);
       }
-      if (!b[columnName].localeCompare) {
+      if (!bValue.localeCompare) {
         return 1;
       }
-      return b[columnName].localeCompare(a[columnName]);
+      return bValue.localeCompare(aValue);
     };
   };
   self.sorters.number = function (columnName, direction) {


### PR DESCRIPTION
fix: issue #264

and
fix: string sort when value is null/undefined
![动画](https://user-images.githubusercontent.com/18085334/139816459-ff407f24-41dc-4202-be1e-b61a26be4725.gif)

and
fix: endless loop aused by set orderDirection/orderBy when addEventListener('beforesortcolumn')
```
grid.addEventListener('beforesortcolumn', (e) => {
  e.preventDefault();
  grid.orderBy = e.name;
  grid.orderDirection = e.direction;
  // ...sort fn
  grid.refresh();
});
```



