### PR TITLE
Fix Fiddle resource path

### DIFF
--- a/tutorials/js/main.js
+++ b/tutorials/js/main.js
@@ -285,7 +285,7 @@
                         js: '',
                         title: msg[0],
                         description: msg[1] || msg[0],
-                        resources: 'https://tonygermaneri.github.io/canvas-datagrid/dist/canvas-datagrid.js',
+                        resources: 'https://canvas-datagrid.js.org/canvas-datagrid.js',
                         dtd: 'html 5'
                     };
                 Object.keys(fiddleForm).forEach(function (k) {


### PR DESCRIPTION
The tutorial Fiddles currently do not work.  The path given to canvas-datagrid.js file is no longer valid.
