### PR TITLE
fix: endless loop aused by set orderDirection/orderBy when addEventLi…

### DIFF
--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1080,7 +1080,6 @@ export default function (self, ctor) {
         value = 'asc';
       }
       self.orderDirection = value;
-      self.order(self.orderBy, self.orderDirection);
     },
   });
   Object.defineProperty(self.intf, 'orderBy', {
@@ -1096,7 +1095,6 @@ export default function (self, ctor) {
         throw new Error('Cannot sort by unknown column name.');
       }
       self.orderBy = value;
-      self.order(self.orderBy, self.orderDirection);
     },
   });
   if (self.isComponent) {


### PR DESCRIPTION
fix: endless loop aused by set orderDirection/orderBy when addEventListener('beforesortcolumn')
```
grid.addEventListener('beforesortcolumn', (e) => {
  e.preventDefault();
  grid.orderBy = e.name;
  grid.orderDirection = e.direction;
  // implement server side ordering
  grid.refresh();
});
```
