### PR TITLE
fix: cant copy when column name or cell value is number

### DIFF
--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1740,6 +1740,7 @@ export default function (self) {
       firstRowKeys,
       isNeat = true; // Selected like [[0, 1], [0, 1]] of [[0, 3]] is neat; Selected like [[0, 1], [1, 2]] is untidy
     function htmlSafe(v) {
+      if (typeof v === 'number') return v;
       return v.replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
     s.forEach(function (column, columnIndex) {
@@ -1753,8 +1754,8 @@ export default function (self) {
         if (!firstRowKeys) firstRowKeys = Object.keys(row);
         if (isNeat && rowKeys.length !== firstRowKeys.length) isNeat = false;
         sSorted.forEach(function (column, columnIndex) {
-          if (rowKeys.indexOf(column.name) < 0) {
-            if (firstRowKeys.indexOf(column.name) < 0) {
+          if (rowKeys.indexOf(String(column.name)) < 0) {
+            if (firstRowKeys.indexOf(String(column.name)) < 0) {
               return;
             } else if (isNeat) {
               isNeat = false;


### PR DESCRIPTION
cant copy when column name or cell value is number

example data
```
const schema = [{"name": 0, "title":"id", "type": "number"}, {"name": 1, "title":"name", "type": "string"}];
const data = [
    [1, 'foo'],
    [2, null],
];
```