### PR TITLE
Add `afterdelete` event and `deleteSelectedData()` public method

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -461,6 +461,14 @@
  * @param {object} e.boundColumnIndexMap Mapping of view column order to bound column order.
  */
 /**
+ * Fires when the selection is cleared by pressing backspace or delete key.
+ * @event
+ * @name canvasDatagrid#selectioncleared
+ * @param {object} e Event object.
+ * @param {object} e.ctx Canvas context.
+ * @param {array} e.cells Cells affected by the clear action. Each item in the array is a tuple of [rowIndex, columnIndex, boundRowIndex, boundColumnIndex].
+ */
+/**
  * Fires when the user clicks on the "drill in" arrow.  When the arrow is clicked a new
  * grid is created and nested inside of the row.  The grid, the row data and row index are passed
  * to the event listener.  From here you can manipulate the inner grid.  A grid is not disposed
@@ -552,7 +560,7 @@
  * @name canvasDatagrid#afterpaste
  * @param {object} e Event object
  * @param {object} e.ctx Canvas context.
- * @param {array} e.cells Cells affected by the paste action. Each item in the array is a tuple of [rowIndex, columnIndex].
+ * @param {array} e.cells Cells affected by the paste action. Each item in the array is a tuple of [rowIndex, columnIndex, boundRowIndex, boundColumnIndex].
  */
 /**
  * Fired just before a cell is drawn onto the canvas.  `e.preventDefault();` prevents the cell from being drawn.

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -461,12 +461,12 @@
  * @param {object} e.boundColumnIndexMap Mapping of view column order to bound column order.
  */
 /**
- * Fires when the selection is cleared by pressing backspace or delete key.
+ * Fires when the selected is deleted by pressing backspace or delete key.
  * @event
- * @name canvasDatagrid#selectioncleared
+ * @name canvasDatagrid#afterdelete
  * @param {object} e Event object.
  * @param {object} e.ctx Canvas context.
- * @param {array} e.cells Cells affected by the clear action. Each item in the array is a tuple of [rowIndex, columnIndex, boundRowIndex, boundColumnIndex].
+ * @param {array} e.cells Cells affected by the delete action. Each item in the array is a tuple of [rowIndex, columnIndex, boundRowIndex, boundColumnIndex].
  */
 /**
  * Fires when the user clicks on the "drill in" arrow.  When the arrow is clicked a new

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1421,7 +1421,7 @@ export default function (self) {
     } else if (ctrl && e.key === 'a') {
       self.selectAll();
     } else if (['Backspace', 'Delete'].includes(e.key)) {
-      self.clearSelection();
+      self.deleteSelectedData();
     } else if (e.key === 'ArrowDown') {
       y += 1;
     } else if (e.key === 'ArrowUp') {

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1863,6 +1863,8 @@ export default function (self) {
     if (self.dispatchEvent('cut', { NativeEvent: e, cells: affectedCells })) {
       return;
     }
+
+    requestAnimationFrame(() => self.draw());
   };
   self.copy = function (e) {
     if (self.dispatchEvent('copy', { NativeEvent: e })) {

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1420,6 +1420,8 @@ export default function (self) {
       self.selectNone();
     } else if (ctrl && e.key === 'a') {
       self.selectAll();
+    } else if (['Backspace', 'Delete'].includes(e.key)) {
+      self.clearSelection();
     } else if (e.key === 'ArrowDown') {
       y += 1;
     } else if (e.key === 'ArrowUp') {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -734,7 +734,7 @@ export default function (self, ctor) {
     self.pointerLockPosition = { x: 0, y: 0 };
     Object.keys(self.style).forEach(self.parseStyleValue);
     self.intf.moveSelection = self.moveSelection;
-    self.intf.clearSelection = self.clearSelection;
+    self.intf.deleteSelectedData = self.deleteSelectedData;
     self.intf.moveTo = self.moveTo;
     self.intf.addEventListener = self.addEventListener;
     self.intf.removeEventListener = self.removeEventListener;

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -734,6 +734,7 @@ export default function (self, ctor) {
     self.pointerLockPosition = { x: 0, y: 0 };
     Object.keys(self.style).forEach(self.parseStyleValue);
     self.intf.moveSelection = self.moveSelection;
+    self.intf.clearSelection = self.clearSelection;
     self.intf.moveTo = self.moveTo;
     self.intf.addEventListener = self.addEventListener;
     self.intf.removeEventListener = self.removeEventListener;

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -242,6 +242,38 @@ export default function (self, ctor) {
 
     return selectedCells;
   };
+  self.clearSelectedCells = function () {
+    const schema = self.getSchema();
+    const affectedCells = [];
+
+    for (const [rowIndex, row] of self.selections.entries()) {
+      // If no cells are selected for a particular rowIndex the selections array will contain an empty element for that rowIndex.
+      if (!row) continue;
+
+      const boundRowIndex = self.getBoundRowIndexFromViewRowIndex(rowIndex);
+
+      for (let columnIndex of row) {
+        // If the whole row is selected the columnIndex for the rowHeader is -1.
+        if (columnIndex < 0) continue;
+
+        const boundColumnIndex = self.getBoundColumnIndexFromViewColumnIndex(
+          columnIndex,
+        );
+        const columnName = schema[boundColumnIndex].name;
+
+        self.viewData[boundRowIndex][columnName] = null;
+
+        affectedCells.push([
+          rowIndex,
+          columnIndex,
+          boundRowIndex,
+          boundColumnIndex,
+        ]);
+      }
+    }
+
+    return affectedCells;
+  };
   self.getBoundRowIndexFromViewRowIndex = function (viewRowIndex) {
     if (self.boundRowIndexMap && self.boundRowIndexMap.has(viewRowIndex)) {
       return self.boundRowIndexMap.get(viewRowIndex);

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -857,12 +857,12 @@ export default function (self) {
     self.selections = sel;
   };
   /**
-   * Clears current selection.
+   * Deletes currently selected data.
    * @memberof canvasDatagrid
-   * @name clearSelection
+   * @name deleteSelectedData
    * @method
    */
-  self.clearSelection = function () {
+  self.deleteSelectedData = function () {
     const affectedCells = [];
     const schema = self.getSchema();
 
@@ -892,7 +892,7 @@ export default function (self) {
       }
     }
 
-    self.dispatchEvent('selectioncleared', {
+    self.dispatchEvent('afterdelete', {
       cells: affectedCells,
     });
   };

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -861,8 +861,9 @@ export default function (self) {
    * @memberof canvasDatagrid
    * @name deleteSelectedData
    * @method
+   * @param {boolean} dontDraw Suppress the draw method after the selection change.
    */
-  self.deleteSelectedData = function () {
+  self.deleteSelectedData = function (dontDraw) {
     const affectedCells = [];
     const schema = self.getSchema();
 
@@ -895,6 +896,11 @@ export default function (self) {
     self.dispatchEvent('afterdelete', {
       cells: affectedCells,
     });
+
+    if (dontDraw) {
+      return;
+    }
+    self.draw();
   };
   /**
    * Moves data in the provided selection to another position in the grid.  Moving data off the edge of the schema (columns/x) will truncate data.

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -857,6 +857,46 @@ export default function (self) {
     self.selections = sel;
   };
   /**
+   * Clears current selection.
+   * @memberof canvasDatagrid
+   * @name clearSelection
+   * @method
+   */
+  self.clearSelection = function () {
+    const affectedCells = [];
+    const schema = self.getSchema();
+
+    for (const [rowIndex, row] of self.selections.entries()) {
+      // If no cells are selected for a particular rowIndex the selections array will contain an empty element for that rowIndex.
+      if (!row) continue;
+
+      const boundRowIndex = self.getBoundRowIndexFromViewRowIndex(rowIndex);
+
+      for (let columnIndex of row) {
+        // If the whole row is selected the columnIndex for the rowHeader is -1.
+        if (columnIndex < 0) continue;
+
+        const boundColumnIndex = self.getBoundColumnIndexFromViewColumnIndex(
+          columnIndex,
+        );
+        const columnName = schema[boundColumnIndex].name;
+
+        self.originalData[boundRowIndex][columnName] = null;
+
+        affectedCells.push([
+          rowIndex,
+          columnIndex,
+          boundRowIndex,
+          boundColumnIndex,
+        ]);
+      }
+    }
+
+    self.dispatchEvent('selectioncleared', {
+      cells: affectedCells,
+    });
+  };
+  /**
    * Moves data in the provided selection to another position in the grid.  Moving data off the edge of the schema (columns/x) will truncate data.
    * @memberof canvasDatagrid
    * @name moveTo

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -864,34 +864,7 @@ export default function (self) {
    * @param {boolean} dontDraw Suppress the draw method after the selection change.
    */
   self.deleteSelectedData = function (dontDraw) {
-    const affectedCells = [];
-    const schema = self.getSchema();
-
-    for (const [rowIndex, row] of self.selections.entries()) {
-      // If no cells are selected for a particular rowIndex the selections array will contain an empty element for that rowIndex.
-      if (!row) continue;
-
-      const boundRowIndex = self.getBoundRowIndexFromViewRowIndex(rowIndex);
-
-      for (let columnIndex of row) {
-        // If the whole row is selected the columnIndex for the rowHeader is -1.
-        if (columnIndex < 0) continue;
-
-        const boundColumnIndex = self.getBoundColumnIndexFromViewColumnIndex(
-          columnIndex,
-        );
-        const columnName = schema[boundColumnIndex].name;
-
-        self.originalData[boundRowIndex][columnName] = null;
-
-        affectedCells.push([
-          rowIndex,
-          columnIndex,
-          boundRowIndex,
-          boundColumnIndex,
-        ]);
-      }
-    }
+    const affectedCells = self.clearSelectedCells();
 
     self.dispatchEvent('afterdelete', {
       cells: affectedCells,

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -900,7 +900,8 @@ export default function (self) {
     if (dontDraw) {
       return;
     }
-    self.draw();
+
+    requestAnimationFrame(() => self.draw());
   };
   /**
    * Moves data in the provided selection to another position in the grid.  Moving data off the edge of the schema (columns/x) will truncate data.

--- a/test/editing.js
+++ b/test/editing.js
@@ -553,7 +553,7 @@ export default function () {
       grid.cut({});
     });
   });
-  it('Clearing selection fires `selectioncleared` event', function (done) {
+  it('Clearing selection fires `afterdelete` event', function (done) {
     var grid = g({
       test: this.test,
       data: [{ 'Column A': 'Original value' }],
@@ -562,7 +562,7 @@ export default function () {
     grid.focus();
     grid.selectArea({ top: 0, left: 0, bottom: 0, right: 0 });
 
-    grid.addEventListener('selectioncleared', function (event) {
+    grid.addEventListener('afterdelete', function (event) {
       event.preventDefault();
       doAssert(
         event.cells[0].length == 4,
@@ -571,6 +571,6 @@ export default function () {
       done();
     });
 
-    grid.clearSelection();
+    grid.deleteSelectedData();
   });
 }

--- a/test/editing.js
+++ b/test/editing.js
@@ -553,4 +553,24 @@ export default function () {
       grid.cut({});
     });
   });
+  it('Clearing selection fires `selectioncleared` event', function (done) {
+    var grid = g({
+      test: this.test,
+      data: [{ 'Column A': 'Original value' }],
+    });
+
+    grid.focus();
+    grid.selectArea({ top: 0, left: 0, bottom: 0, right: 0 });
+
+    grid.addEventListener('selectioncleared', function (event) {
+      event.preventDefault();
+      doAssert(
+        event.cells[0].length == 4,
+        'first affected cell is [rowIndex, columnIndex, boundRowIndex, boundColumnIndex] tuple',
+      );
+      done();
+    });
+
+    grid.clearSelection();
+  });
 }

--- a/test/key-navigation.js
+++ b/test/key-navigation.js
@@ -1,4 +1,4 @@
-import { makeData, g, smallData, assertIf } from './util.js';
+import { makeData, g, smallData, assertIf, doAssert } from './util.js';
 
 export default function () {
   it('Arrow down should move active cell down one', function (done) {
@@ -409,6 +409,35 @@ export default function () {
       assertIf(
         grid.activeCell.rowIndex !== 0,
         'Expected the active cell to move.',
+      ),
+    );
+  });
+  it('Selection is cleared when backspace is pressed', function (done) {
+    const data = smallData();
+    var grid = g({
+      test: this.test,
+      data,
+    });
+
+    grid.focus();
+    grid.selectArea({
+      top: 0,
+      left: 0,
+      bottom: 1,
+      right: 1,
+    });
+
+    var ev = new Event('keydown');
+    ev.key = 'Backspace';
+
+    grid.controlInput.dispatchEvent(ev);
+    done(
+      doAssert(
+        grid.data[0].col1 === null &&
+          grid.data[0].col2 === null &&
+          grid.data[1].col1 === null &&
+          grid.data[1].col2 === null,
+        'Expected cells to be cleared.',
       ),
     );
   });


### PR DESCRIPTION
Natively support clearing selected data pressing Delete/Backspace. Clearing selected data fires a `afterdelete` event containing affected cells (an array of tuples in the shape of `[rowIndex, columnIndex, boundRowIndex, boundColumnIndex]`).

This addresses #412.

See https://ynoqp.csb.app/ for interactive demo.