### PR TITLE
Fire event when resizing column by double clicking

### DIFF
--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -734,9 +734,23 @@ export default function (self) {
     if (!self.canvas) {
       return;
     }
-    self.sizes.columns[
-      name === 'cornerCell' ? -1 : self.getHeaderByName(name).index
-    ] = Math.max(self.findColumnMaxTextLength(name), self.style.minColumnWidth);
+
+    const columnIndex =
+      name === 'cornerCell' ? -1 : self.getHeaderByName(name).index;
+
+    const newSize = Math.max(
+      self.findColumnMaxTextLength(name),
+      self.style.minColumnWidth,
+    );
+
+    self.sizes.columns[columnIndex] = newSize;
+
+    self.dispatchEvent('resizecolumn', {
+      x: newSize,
+      y: self.resizingStartingHeight,
+      draggingItem: self.currentCell,
+    });
+
     if (!internal) {
       self.resize();
       self.draw(true);

--- a/test/resize.js
+++ b/test/resize.js
@@ -6,6 +6,8 @@ import {
   g,
   smallData,
   c,
+  doAssert,
+  dblclick,
 } from './util.js';
 
 export default function () {
@@ -30,6 +32,23 @@ export default function () {
     setTimeout(function () {
       assertPxColor(grid, 100, 36, c.b, done);
     }, 10);
+  });
+  it('Resize a column by double clicking a column header.', function (done) {
+    var grid = g({
+      test: this.test,
+      data: smallData(),
+      style: {
+        cellWidth: 50,
+      },
+    });
+
+    grid.addEventListener('resizecolumn', function (e) {
+      doAssert(e.x === grid.sizes.columns[0], 'x matches width of column 0');
+      done();
+    });
+    grid.focus();
+    mousemove(document.body, 94, 10, grid.canvas);
+    dblclick(grid.canvas, 94, 10);
   });
   it('Resize a column from a cell.', function (done) {
     var grid = g({


### PR DESCRIPTION
Double clicking a column border autoresizes the column width (to fit widest cell) but does not emit a `resizecolumn` event. 

This PR fixes this.