### PR TITLE
Refactor `cut` and `copy` event handlers

### DIFF
--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1842,35 +1842,22 @@ export default function (self) {
     });
   };
   self.cut = function (e) {
-    self.copy(e);
-    const schema = self.getSchema();
-
-    var affectedCells = [];
-    for (const [rowIndex, row] of self.selections.entries()) {
-      if (!row) continue;
-
-      const boundRowIndex = self.getBoundRowIndexFromViewRowIndex(rowIndex);
-
-      for (const columnIndex of row) {
-        const boundColumnIndex = self.getBoundColumnIndexFromViewColumnIndex(
-          columnIndex,
-        );
-        const colName = schema[boundColumnIndex].name;
-
-        self.viewData[rowIndex][colName] = '';
-
-        affectedCells.push([
-          rowIndex,
-          columnIndex,
-          boundRowIndex,
-          boundColumnIndex,
-        ]);
-      }
-    }
-
-    if (self.dispatchEvent('cut', { NativeEvent: e, cells: affectedCells })) {
+    if (self.dispatchEvent('cut', { NativeEvent: e })) {
       return;
     }
+
+    // If event has `clipboardData` it implements the ClipboardEvent interface.
+    if (!self.hasFocus || !e.clipboardData) {
+      return;
+    }
+
+    self.copySelectedCellsToClipboard(e.clipboardData);
+
+    const affectedCells = self.clearSelectedCells();
+
+    self.dispatchEvent('aftercut', {
+      cells: affectedCells,
+    });
 
     requestAnimationFrame(() => self.draw());
   };
@@ -1878,70 +1865,15 @@ export default function (self) {
     if (self.dispatchEvent('copy', { NativeEvent: e })) {
       return;
     }
+
+    // If event has `clipboardData` it implements the ClipboardEvent interface.
     if (!self.hasFocus || !e.clipboardData) {
       return;
     }
-    var t = '',
-      d = '',
-      textRows = [],
-      sData = self.getSelectedData(),
-      s = self.getSchema(),
-      sSorted = [],
-      firstRowKeys,
-      isNeat = true; // Selected like [[0, 1], [0, 1]] of [[0, 3]] is neat; Selected like [[0, 1], [1, 2]] is untidy
-    function htmlSafe(v) {
-      if (typeof v === 'number') return v;
-      return v.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    }
-    s.forEach(function (column, columnIndex) {
-      sSorted.push(s[self.orders.columns[columnIndex]]);
-    });
-    if (sData.length > 0) {
-      sData.forEach((row) => {
-        if (!row) return;
-        var rowKeys = Object.keys(row);
-        var textRow = [];
-        if (!firstRowKeys) firstRowKeys = Object.keys(row);
-        if (isNeat && rowKeys.length !== firstRowKeys.length) isNeat = false;
-        sSorted.forEach(function (column, columnIndex) {
-          if (rowKeys.indexOf(String(column.name)) < 0) {
-            if (firstRowKeys.indexOf(String(column.name)) < 0) {
-              return;
-            } else if (isNeat) {
-              isNeat = false;
-            }
-          }
-          textRow.push(row[column.name] || '');
-        });
-        textRows.push(textRow);
-      });
-      if (isNeat) {
-        t = textRows.map((row) => row.join('\t')).join('\n');
-        /**
-         * The html content copied by Excel has not header
-         */
-        d += '<table>';
-        d += textRows
-          .map(
-            (row) =>
-              '<tr>' +
-              row.map((value) => '<td>' + htmlSafe(value) + '</td>').join('') +
-              '</tr>',
-          )
-          .join('');
-        d += '</table>';
-      } else {
-        t = textRows.map((row) => row.join('')).join('');
-        d = t;
-      }
-      if (t) {
-        e.clipboardData.setData('text/html', d);
-        e.clipboardData.setData('text/plain', t);
-        e.clipboardData.setData('text/csv', t);
-        e.clipboardData.setData('application/json', JSON.stringify(sData));
-      }
-      e.preventDefault();
-    }
+
+    self.copySelectedCellsToClipboard(e.clipboardData);
+
+    e.preventDefault();
   };
   return;
 }

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1846,7 +1846,7 @@ export default function (self) {
       return;
     }
 
-    // If event has `clipboardData` it implements the ClipboardEvent interface.
+    // Expecting instance of `ClipboardEvent` with `clipboardData` attribute
     if (!self.hasFocus || !e.clipboardData) {
       return;
     }
@@ -1866,7 +1866,7 @@ export default function (self) {
       return;
     }
 
-    // If event has `clipboardData` it implements the ClipboardEvent interface.
+    // Expecting instance of `ClipboardEvent` with `clipboardData` attribute
     if (!self.hasFocus || !e.clipboardData) {
       return;
     }

--- a/lib/events/util.js
+++ b/lib/events/util.js
@@ -86,11 +86,46 @@ const parseData = function (data, mimeType) {
   return parseText(data);
 };
 
+const htmlSafe = (value) => {
+  if (typeof value === 'number') return value;
+  return value.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+};
+
+const createTextString = (selectedData, isNeat) => {
+  if (!isNeat)
+    return selectedData.map((row) => Object.values(row).join('')).join('');
+
+  return selectedData.map((row) => Object.values(row).join('\t')).join('\n');
+};
+
+const createHTMLString = (selectedData, isNeat) => {
+  if (!isNeat) return createTextString(selectedData, isNeat);
+
+  // The html content copied by Excel has not header.
+  let htmlString = '<table>';
+  htmlString += selectedData
+    .map(
+      (row) =>
+        '<tr>' +
+        Object.values(row)
+          .map((value) => '<td>' + htmlSafe(value) + '</td>')
+          .join('') +
+        '</tr>',
+    )
+    .join('');
+  htmlString += '</table>';
+
+  return htmlString;
+};
+
 export {
+  createTextString,
+  createHTMLString,
   isSupportedHtml,
-  sanitizeElementData,
+  htmlSafe,
   parseData,
   parseHtmlTable,
   parseHtmlText,
   parseText,
+  sanitizeElementData,
 };

--- a/lib/events/util.js
+++ b/lib/events/util.js
@@ -92,16 +92,19 @@ const htmlSafe = (value) => {
 };
 
 const createTextString = (selectedData, isNeat) => {
+  // Selected like [[0, 1], [0, 1]] of [[0, 3]] is neat; Selected like [[0, 1], [1, 2]] is untidy.
+  // If not isNeat we just return a simple string of concatenated values.
   if (!isNeat)
     return selectedData.map((row) => Object.values(row).join('')).join('');
 
+  // If isNeat, we can create tab separated mutti-line text.
   return selectedData.map((row) => Object.values(row).join('\t')).join('\n');
 };
 
 const createHTMLString = (selectedData, isNeat) => {
   if (!isNeat) return createTextString(selectedData, isNeat);
 
-  // The html content copied by Excel has not header.
+  // If isNeat, we can create a HTML table with the selected data.
   let htmlString = '<table>';
   htmlString += selectedData
     .map(

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -2,6 +2,8 @@
 /*globals HTMLElement: false, Reflect: false, define: true, MutationObserver: false, requestAnimationFrame: false, performance: false, btoa: false*/
 'use strict';
 
+import { createHTMLString, createTextString } from './events/util';
+
 export default function (self, ctor) {
   self.scale = 1;
   self.orders = {
@@ -241,6 +243,56 @@ export default function (self, ctor) {
     }
 
     return selectedCells;
+  };
+  self.copySelectedCellsToClipboard = function (clipboardData) {
+    const selectedData = [];
+    const schema = self.getSchema();
+    let firstRowKeys;
+    let isNeat = true; // Selected like [[0, 1], [0, 1]] of [[0, 3]] is neat; Selected like [[0, 1], [1, 2]] is untidy
+
+    for (const [rowIndex, row] of self.selections.entries()) {
+      // If no cells are selected for a particular rowIndex the selections array will contain an empty element for that rowIndex.
+      if (!row) continue;
+
+      const rowKeys = Object.keys(row);
+      const rowDict = {};
+
+      if (!firstRowKeys) firstRowKeys = Object.keys(row);
+      if (isNeat && rowKeys.length !== firstRowKeys.length) isNeat = false;
+
+      const boundRowIndex = self.getBoundRowIndexFromViewRowIndex(rowIndex);
+
+      for (let columnIndex of row) {
+        // If the whole row is selected the columnIndex for the rowHeader is -1.
+        if (columnIndex < 0) continue;
+
+        const boundColumnIndex = self.getBoundColumnIndexFromViewColumnIndex(
+          columnIndex,
+        );
+        const columnName = schema[boundColumnIndex].name;
+
+        const value = self.originalData[boundRowIndex][columnName];
+
+        rowDict[columnName] = value;
+      }
+      selectedData.push(rowDict);
+    }
+
+    if (selectedData.length > 0) {
+      const textString = createTextString(selectedData, isNeat);
+      const htmlString = createHTMLString(selectedData, isNeat);
+
+      const copiedData = {
+        'text/plain': textString,
+        'text/html': htmlString,
+        'text/csv': textString,
+        'application/json': JSON.stringify(selectedData),
+      };
+
+      for (const [mimeType, data] of Object.entries(copiedData)) {
+        clipboardData.setData(mimeType, data);
+      }
+    }
   };
   self.clearSelectedCells = function () {
     const schema = self.getSchema();

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -314,7 +314,7 @@ export default function (self, ctor) {
         );
         const columnName = schema[boundColumnIndex].name;
 
-        self.viewData[boundRowIndex][columnName] = null;
+        self.viewData[boundRowIndex][columnName] = '';
 
         affectedCells.push([
           rowIndex,

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -247,18 +247,19 @@ export default function (self, ctor) {
   self.copySelectedCellsToClipboard = function (clipboardData) {
     const selectedData = [];
     const schema = self.getSchema();
-    let firstRowKeys;
+    let firstRowAsString;
     let isNeat = true; // Selected like [[0, 1], [0, 1]] of [[0, 3]] is neat; Selected like [[0, 1], [1, 2]] is untidy
 
     for (const [rowIndex, row] of self.selections.entries()) {
       // If no cells are selected for a particular rowIndex the selections array will contain an empty element for that rowIndex.
       if (!row) continue;
 
-      const rowKeys = Object.keys(row);
+      // Convert to string for easy comparison to the first row.
+      const rowAsString = row.join(',').toString();
       const rowDict = {};
 
-      if (!firstRowKeys) firstRowKeys = Object.keys(row);
-      if (isNeat && rowKeys.length !== firstRowKeys.length) isNeat = false;
+      if (!firstRowAsString) firstRowAsString = row.join(',').toString();
+      if (isNeat && rowAsString !== firstRowAsString) isNeat = false;
 
       const boundRowIndex = self.getBoundRowIndexFromViewRowIndex(rowIndex);
 

--- a/test/editing.js
+++ b/test/editing.js
@@ -138,52 +138,108 @@ export default function () {
     );
     grid.endEdit();
   });
-  it('Copied data put on simulated clipboard', function (done) {
-    const data = [
-      {
-        d: 'Text with, a comma 1',
-        e: 'Text that has no comma in in 1',
-      },
-      {
-        d: 'Text with, a comma 2',
-        e: 'Text that has no comma in in 2',
-      },
-    ];
+  describe('copy', function () {
+    it('neatly selected data onto simulated clipboard', function (done) {
+      const data = [
+        {
+          d: 'Text with, a comma 1',
+          e: 'Text that has no comma in in 1',
+        },
+        {
+          d: 'Text with, a comma 2',
+          e: 'Text that has no comma in in 2',
+        },
+      ];
 
-    const grid = g({
-      test: this.test,
-      data,
+      const grid = g({
+        test: this.test,
+        data,
+      });
+
+      grid.selectAll();
+      grid.focus();
+
+      const textResult = `Text with, a comma 1\tText that has no comma in in 1\nText with, a comma 2\tText that has no comma in in 2`;
+      const htmlResult =
+        '<table><tr><td>Text with, a comma 1</td><td>Text that has no comma in in 1</td></tr><tr><td>Text with, a comma 2</td><td>Text that has no comma in in 2</td></tr></table>';
+      const jsonResult = JSON.stringify(data);
+
+      grid.copy(new Object(fakeClipboardEvent));
+      const { clipboardData } = fakeClipboardEvent;
+
+      doAssert(
+        clipboardData.data['text/plain'] === textResult,
+        'Expected plain text to be copied',
+      );
+      doAssert(
+        clipboardData.data['text/html'] === htmlResult,
+        'Expected html to be copied',
+      );
+      doAssert(
+        clipboardData.data['text/csv'] === textResult,
+        'Expected csv text to be copied',
+      );
+      doAssert(
+        clipboardData.data['application/json'] === jsonResult,
+        'Expected json to be copied',
+      );
+
+      done();
     });
+    it('untidy selected data onto simulated clipboard', function (done) {
+      const data = [
+        {
+          d: 'Text with, a comma 1',
+          e: 'Text that has no comma in in 1',
+        },
+        {
+          d: 'Text with, a comma 2',
+          e: 'Text that has no comma in in 2',
+        },
+      ];
 
-    grid.selectAll();
-    grid.focus();
+      const grid = g({
+        test: this.test,
+        data,
+      });
 
-    const textResult = `Text with, a comma 1\tText that has no comma in in 1\nText with, a comma 2\tText that has no comma in in 2`;
-    const htmlResult =
-      '<table><tr><td>Text with, a comma 1</td><td>Text that has no comma in in 1</td></tr><tr><td>Text with, a comma 2</td><td>Text that has no comma in in 2</td></tr></table>';
-    const jsonResult = JSON.stringify(data);
+      grid.selectArea({ top: 0, left: 0, bottom: 0, right: 0 });
+      grid.selectArea({ top: 1, left: 1, bottom: 1, right: 1 }, true); // ctrl = true, adds to previous selection
+      grid.focus();
 
-    grid.copy(new Object(fakeClipboardEvent));
-    const { clipboardData } = fakeClipboardEvent;
+      const textResult = `Text with, a comma 1Text that has no comma in in 2`;
+      const htmlResult = textResult;
+      const jsonResult = JSON.stringify([
+        {
+          d: 'Text with, a comma 1',
+        },
+        {
+          e: 'Text that has no comma in in 2',
+        },
+      ]);
 
-    doAssert(
-      clipboardData.data['text/plain'] === textResult,
-      'Expected plain text to be copied',
-    );
-    doAssert(
-      clipboardData.data['text/html'] === htmlResult,
-      'Expected html to be copied',
-    );
-    doAssert(
-      clipboardData.data['text/csv'] === textResult,
-      'Expected csv text to be copied',
-    );
-    doAssert(
-      clipboardData.data['application/json'] === jsonResult,
-      'Expected json to be copied',
-    );
+      grid.copy(new Object(fakeClipboardEvent));
+      const { clipboardData } = fakeClipboardEvent;
 
-    done();
+      doAssert(
+        clipboardData.data['text/plain'] === textResult,
+        'Expected plain text to be copied',
+      );
+      doAssert(
+        clipboardData.data['text/html'] === htmlResult,
+        'Expected html to be copied',
+      );
+      doAssert(
+        clipboardData.data['text/csv'] === textResult,
+        'Expected csv text to be copied',
+      );
+      doAssert(
+        clipboardData.data['application/json'] === jsonResult,
+        'Expected json to be copied',
+      );
+
+      done();
+    });
   });
   it('Should paste a value from the clipboard into a cell', function (done) {
     var grid = g({
@@ -288,7 +344,6 @@ export default function () {
       );
     }, 10);
   });
-
   it('paste a Excel table with multiple rows from the clipboard', function (done) {
     var grid = g({
       test: this.test,

--- a/test/editing.js
+++ b/test/editing.js
@@ -9,6 +9,16 @@ import {
   assertIf,
 } from './util.js';
 
+const fakeClipboardEvent = {
+  clipboardData: {
+    data: {},
+    setData: function (mime, data) {
+      this.data[mime] = data;
+    },
+  },
+  preventDefault: () => null, // noop so the call in addCellValue doesn't cause an error
+};
+
 export default function () {
   it('Begin editing, end editing', function (done) {
     var ev,
@@ -128,42 +138,52 @@ export default function () {
     );
     grid.endEdit();
   });
-  it.skip('Should copy a value onto the simulated clipboard.', function (done) {
-    var once,
-      grid = g({
-        test: this.test,
-        data: [
-          {
-            d: 'Text with, a comma 1',
-            e: 'Text that has no comma in in 1',
-          },
-          {
-            d: 'Text with, a comma 2',
-            e: 'Text that has no comma in in 2',
-          },
-        ],
-      });
+  it('Copied data put on simulated clipboard', function (done) {
+    const data = [
+      {
+        d: 'Text with, a comma 1',
+        e: 'Text that has no comma in in 1',
+      },
+      {
+        d: 'Text with, a comma 2',
+        e: 'Text that has no comma in in 2',
+      },
+    ];
+
+    const grid = g({
+      test: this.test,
+      data,
+    });
+
     grid.selectAll();
     grid.focus();
-    setTimeout(function () {
-      grid.copy({
-        clipboardData: {
-          setData: function (mime, data) {
-            if (once) {
-              return;
-            }
-            once = true;
-            done(
-              assertIf(
-                mime !== 'text/html' || data.indexOf('Text with') === -1,
-                'Expected data from the grid to be placed into the fake clipboard.',
-              ),
-            );
-          },
-        },
-        preventDefault: () => null, // noop so the call in addCellValue doesn't cause an error
-      });
-    }, 1);
+
+    const textResult = `Text with, a comma 1\tText that has no comma in in 1\nText with, a comma 2\tText that has no comma in in 2`;
+    const htmlResult =
+      '<table><tr><td>Text with, a comma 1</td><td>Text that has no comma in in 1</td></tr><tr><td>Text with, a comma 2</td><td>Text that has no comma in in 2</td></tr></table>';
+    const jsonResult = JSON.stringify(data);
+
+    grid.copy(new Object(fakeClipboardEvent));
+    const { clipboardData } = fakeClipboardEvent;
+
+    doAssert(
+      clipboardData.data['text/plain'] === textResult,
+      'Expected plain text to be copied',
+    );
+    doAssert(
+      clipboardData.data['text/html'] === htmlResult,
+      'Expected html to be copied',
+    );
+    doAssert(
+      clipboardData.data['text/csv'] === textResult,
+      'Expected csv text to be copied',
+    );
+    doAssert(
+      clipboardData.data['application/json'] === jsonResult,
+      'Expected json to be copied',
+    );
+
+    done();
   });
   it('Should paste a value from the clipboard into a cell', function (done) {
     var grid = g({
@@ -527,7 +547,7 @@ export default function () {
     grid.endEdit();
   });
   describe('cut', function () {
-    it('fires a cut event', function (done) {
+    it('fires a aftercut event with affected cells', function (done) {
       var grid = g({
         test: this.test,
         data: [{ 'Column A': 'Original value' }],
@@ -537,7 +557,7 @@ export default function () {
       grid.setActiveCell(0, 0);
       grid.selectArea({ top: 0, left: 0, bottom: 0, right: 0 });
 
-      grid.addEventListener('cut', function (event) {
+      grid.addEventListener('aftercut', function (event) {
         try {
           doAssert(!!event.cells, 'event has cells property');
           doAssert(event.cells.length === 1, 'one row has been pasted ');
@@ -550,7 +570,7 @@ export default function () {
         done();
       });
 
-      grid.cut({});
+      grid.cut(fakeClipboardEvent);
     });
   });
   it('Clearing selection fires `afterdelete` event', function (done) {

--- a/test/key-navigation.js
+++ b/test/key-navigation.js
@@ -433,10 +433,10 @@ export default function () {
     grid.controlInput.dispatchEvent(ev);
     done(
       doAssert(
-        grid.data[0].col1 === null &&
-          grid.data[0].col2 === null &&
-          grid.data[1].col1 === null &&
-          grid.data[1].col2 === null,
+        grid.data[0].col1 === '' &&
+          grid.data[0].col2 === '' &&
+          grid.data[1].col1 === '' &&
+          grid.data[1].col2 === '',
         'Expected cells to be cleared.',
       ),
     );


### PR DESCRIPTION
The cut event handler currently dispatches a `copy` and `cut` event. The copy is fired by reuse of the `copy` event handler and the data is removed from the grid before the `cut` event is dispatched. This is not in line with the [W3C Clipboard API](https://w3c.github.io/clipboard-apis/#clipboard-event-cut) which reads:

> In an editable context, if the event is not canceled the action will place the currently selected data on the system clipboard and remove the selection from the document. The cut event fires before the selected data is removed. When the cut operation is completed, the selection is collapsed.

This PR refactors the `cut` event handler to:

- Move selected-cell-copy-logic to a utility function so it can be used in both `cut` and `copy` event handler.
- Copy selected data to the clipboard but not dispatch a `copy` event.
- (Re)-Dispatch  `cut` event before anything happens.
- Clear selected data and then dispatch a custom`aftercut` event with an array of affected cells (usable in calling application).
- Add/enable tests for neat and untidy copy actions.

In #383 I added `affectedCells` to the `cut` event, this PR breaks this by introducing an `aftercut` event with those cells. I would think impact of this is very limited.

Here's a demo: https://3nvso.csb.app/
