### PR TITLE
Resize selected columns simultaneously

### DIFF
--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -797,7 +797,27 @@ export default function (self) {
     }
     self.ellipsisCache = {};
   };
-  self.stopDragResize = function () {
+  self.stopDragResize = function (e) {
+    const pos = self.getLayerPos(e);
+    const hasMoved = !!(pos.x - self.dragStart.x);
+    const width = self.resizingStartingWidth + pos.x - self.dragStart.x;
+
+    if (self.dragMode === 'ew-resize') {
+      const selectedColumns = self.selections[0];
+      const dragItemIsSelected = self.isColumnSelected(
+        self.dragItem.columnIndex,
+      );
+
+      if (dragItemIsSelected)
+        for (const selectedColumn of selectedColumns)
+          if (
+            hasMoved &&
+            dragItemIsSelected &&
+            self.isColumnSelected(selectedColumn)
+          )
+            self.sizes.columns[selectedColumn] = width;
+    }
+
     self.resize();
     document.body.removeEventListener(
       'mousemove',

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -1634,7 +1634,17 @@ export default function (self) {
       self.currentCell.context === 'ew-resize' &&
       self.currentCell.style === 'columnHeaderCell'
     ) {
-      self.fitColumnToValues(self.currentCell.header.name);
+      // Check that double-clicked cell is selected or part of selection.
+      const currentCellIsSelected = self.isColumnSelected(
+        self.currentCell.columnIndex,
+      );
+
+      if (currentCellIsSelected) {
+        // There might be more
+        self.fitSelectedColumns();
+      } else {
+        self.fitColumnToValues(self.currentCell.header.name);
+      }
     } else if (
       self.currentCell.context === 'ew-resize' &&
       self.currentCell.style === 'cornerCell'

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -809,13 +809,18 @@ export default function (self) {
       );
 
       if (dragItemIsSelected)
-        for (const selectedColumn of selectedColumns)
+        for (const selectedColumnIndex of selectedColumns) {
+          const boundColumnIndex = self.getBoundColumnIndexFromViewColumnIndex(
+            selectedColumnIndex,
+          );
+
           if (
             hasMoved &&
             dragItemIsSelected &&
-            self.isColumnSelected(selectedColumn)
+            self.isColumnSelected(selectedColumnIndex)
           )
-            self.sizes.columns[selectedColumn] = width;
+            self.sizes.columns[boundColumnIndex] = width;
+        }
     }
 
     self.resize();

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -396,6 +396,18 @@ export default function (self, ctor) {
   self.createRowOrders = function () {
     self.orders.rows = fillArray(0, self.originalData.length - 1);
   };
+  self.fitSelectedColumns = function () {
+    const selectedColumns = self.selections[0];
+    const schema = self.getSchema();
+
+    for (const selectedColumn of selectedColumns) {
+      // Make sure the column is not the row header and that the whole column has in fact been selected.
+      if (selectedColumn >= 0 && self.isColumnSelected(selectedColumn)) {
+        const column = schema[self.orders.columns[selectedColumn]];
+        self.fitColumnToValues(column.name);
+      }
+    }
+  };
   self.getVisibleSchema = function () {
     return self.getSchema().filter(function (col) {
       return !col.hidden;

--- a/test/resize.js
+++ b/test/resize.js
@@ -33,7 +33,7 @@ export default function () {
       assertPxColor(grid, 100, 36, c.b, done);
     }, 10);
   });
-  it('Resizes all selected columns.', function () {
+  it('Resizes selected columns.', function () {
     var grid = g({
       test: this.test,
       data: smallData(),
@@ -87,6 +87,32 @@ export default function () {
     grid.focus();
     mousemove(document.body, 94, 10, grid.canvas);
     dblclick(grid.canvas, 94, 10);
+  });
+  it('Resize selected columns by double clicking a column header.', function () {
+    var grid = g({
+      test: this.test,
+      data: smallData(),
+      style: {
+        cellWidth: 50,
+      },
+    });
+
+    grid.selectColumn(0);
+    grid.selectColumn(1, true);
+
+    chai.assert.deepStrictEqual(Object.keys(grid.sizes.columns),
+      ['-1'],
+      'No column widths set',
+    );
+
+    mousemove(document.body, 94, 10, grid.canvas);
+    dblclick(grid.canvas, 94, 10);
+
+    chai.assert.deepStrictEqual(Object.keys(grid.sizes.columns), [
+      '0',
+      '1',
+      '-1',
+    ]);
   });
   it('Resize a column from a cell.', function (done) {
     var grid = g({

--- a/test/resize.js
+++ b/test/resize.js
@@ -33,6 +33,44 @@ export default function () {
       assertPxColor(grid, 100, 36, c.b, done);
     }, 10);
   });
+  it('Resizes all selected columns.', function () {
+    var grid = g({
+      test: this.test,
+      data: smallData(),
+      style: {
+        cellWidth: 50,
+      },
+    });
+    grid.focus();
+    grid.selectColumn(0);
+    grid.selectColumn(1, true);
+
+    const columnSizes = Object.keys(grid.sizes.columns);
+    doAssert(
+      columnSizes.length === 1 && columnSizes[0] === '-1',
+      'No column widths set',
+    );
+
+    mousemove(document.body, 94, 10, grid.canvas);
+    mousedown(grid.canvas, 94, 10);
+    mousemove(document.body, 190, 10, grid.canvas);
+    mouseup(document.body, 190, 10, grid.canvas);
+
+    doAssert(
+      grid.sizes.columns[0] === grid.sizes.columns[1],
+      'Columns have same width',
+    );
+
+    mousemove(document.body, 190, 10, grid.canvas);
+    mousedown(grid.canvas, 190, 10);
+    mousemove(document.body, 94, 10, grid.canvas);
+    mouseup(document.body, 94, 10, grid.canvas);
+
+    doAssert(
+      grid.sizes.columns[0] === 50 && grid.sizes.columns[1] === 50,
+      'Columns have been set back to original width',
+    );
+  });
   it('Resize a column by double clicking a column header.', function (done) {
     var grid = g({
       test: this.test,


### PR DESCRIPTION
This moves Canvas Datagrid column resizing behaviour more in line with Excel and Google Sheets.

For example, Excel's column resize behaviour (on dragging or double-clicking resize handle):

![CleanShot 2021-12-15 at 17 57 06](https://user-images.githubusercontent.com/101284/146230759-942caa60-8361-4397-bc97-d479ddc19e88.gif)

Canvas Datagrid after merging:

![CleanShot 2021-12-15 at 18 02 19](https://user-images.githubusercontent.com/101284/146231362-26abb977-0016-42ba-a6e1-11cde54bcddd.gif)

Here's a sandbox to try: https://lojcx.csb.app/