### PR TITLE
Fix cell editing in the inner grid

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -143,11 +143,16 @@ export default function (self) {
       s = e,
       h,
       w;
+    let calculatedTree = false;
     while (e.offsetParent && e.nodeName !== 'CANVAS-DATAGRID') {
-      x += e.offsetLeft;
-      y += e.offsetTop;
-      h = e.offsetHeight;
-      w = e.offsetWidth;
+      const isTree = e.nodeType === 'canvas-datagrid-tree';
+      if (!isTree || !calculatedTree) {
+        x += e.offsetLeft;
+        y += e.offsetTop;
+        h = e.offsetHeight;
+        w = e.offsetWidth;
+      }
+      if (isTree) calculatedTree = true;
       e = e.offsetParent;
     }
     if (ignoreScrollOffset) {

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -342,18 +342,25 @@ export default function (self) {
    * @param {number} [offsetY=0] Percentage offset the cell should be from the top edge (not including headers).  The default is 0, meaning the cell will appear at the top edge. Valid values are 0 through 1. 1 = Bottom, 0 = Top, 0.5 = Center.
    */
   self.scrollIntoView = function (x, y, offsetX, offsetY) {
-    if (
-      self.visibleCells.filter(function (cell) {
-        return (
-          (cell.rowIndex === y || y === undefined) &&
-          (cell.columnIndex === x || x === undefined) &&
-          cell.x > 0 &&
-          cell.y > 0 &&
-          cell.x + cell.width < self.width &&
-          cell.y + cell.height < self.height
-        );
-      }).length === 0
-    ) {
+    const matched = self.visibleCells.filter(function (cell) {
+      return (
+        (cell.rowIndex === y || y === undefined) &&
+        (cell.columnIndex === x || x === undefined) &&
+        cell.x > 0 &&
+        cell.y > 0 &&
+        cell.x + cell.width < self.width &&
+        cell.y + cell.height < self.height
+      );
+    });
+    if (matched.length === 1 && x !== undefined && y !== undefined) {
+      // goto specific cell and its part be hidden by header
+      if (
+        matched[0].x < self.getRowHeaderCellWidth() ||
+        matched[0].y < self.getColumnHeaderCellHeight()
+      )
+        matched.length = 0;
+    }
+    if (matched.length === 0) {
       self.gotoCell(x, y, offsetX, offsetY);
     }
   };


### PR DESCRIPTION
* Fix `self.position` method for multi-level nested grids. Add flag `calculatedTree` to avoid calculating offset of nested grid multiple times

* Fix `scrollIntoView `method. Make this method can display the cells fully instead of some parts being hidden by headers

Demo:

* Bugs: <https://qolwi.csb.app/bugs.html>
* Fixed: <https://qolwi.csb.app/index.html>

Reproducing:

1. Scroll right 10px, and double click any column in the first column to edit.
2. Open the inner grid of row 1, then open the inner grid of row 1 of the inner grid you opened. And try to edit the first cell

Screenshots:

<img width="667" alt="Screenshot 2021-12-22 at 15 43 45" src="https://user-images.githubusercontent.com/4303130/147055202-6742c976-b20c-4d1b-a1fd-ef8499cde6ea.png">
<img width="362" alt="Screenshot 2021-12-22 at 15 43 35" src="https://user-images.githubusercontent.com/4303130/147055222-4e81642a-a5af-4875-9055-1549bc103ad8.png">
<img width="493" alt="Screenshot 2021-12-22 at 15 48 43" src="https://user-images.githubusercontent.com/4303130/147055387-3bf04ea0-66c4-414c-b0a4-cf0c37d34ecb.png">



