### PR TITLE
Fix setting property `dragOffset` of undefined

### DIFF
--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -975,6 +975,7 @@ export default function (self) {
           -1,
           self.activeCell.rowIndex,
         );
+      if (!self.reorderObject) return;
       self.reorderTarget = self.currentCell;
       self.reorderObject.dragOffset = {
         x: x,


### PR DESCRIPTION
Fix bug:

``` 
Uncaught TypeError: Cannot set properties of undefined (setting 'dragOffset')
    at HTMLBodyElement.self.dragReorder (index.js:979)
```

Reproducing:

https://user-images.githubusercontent.com/4303130/147653450-40c8734f-937c-4be6-a623-1583fbec4077.mp4


