### PR TITLE
Fix: null values are cast to strings ('null') on copy

### DIFF
--- a/lib/events/util.js
+++ b/lib/events/util.js
@@ -112,7 +112,7 @@ const createHTMLString = function (selectedData, isNeat) {
       (row) =>
         '<tr>' +
         Object.values(row)
-          .map((value) => '<td>' + htmlSafe(value) + '</td>')
+          .map((value) => ['<td>', htmlSafe(value), '</td>'].join(''))
           .join('') +
         '</tr>',
     )

--- a/test/editing.js
+++ b/test/editing.js
@@ -240,6 +240,36 @@ export default function () {
 
       done();
     });
+    it('null value is not cast to `null`', function () {
+      const data = [
+        {
+          d: null,
+        },
+      ];
+
+      const grid = g({
+        test: this.test,
+        data,
+      });
+
+      grid.selectAll();
+      grid.focus();
+
+      const textResult = ``;
+      const htmlResult = '<table><tr><td></td></tr></table>';
+
+      grid.copy(new Object(fakeClipboardEvent));
+      const { clipboardData } = fakeClipboardEvent;
+
+      doAssert(
+        clipboardData.data['text/plain'] === textResult,
+        'Expected plain text to be copied',
+      );
+      doAssert(
+        clipboardData.data['text/html'] === htmlResult,
+        'Expected html text to be copied',
+      );
+    });
   });
   it('Should paste a value from the clipboard into a cell', function (done) {
     var grid = g({


### PR DESCRIPTION
Small fix to avoid casting `null` to a string `'null'`.