### PR TITLE
Fix jsDoc for document site

### DIFF
--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -1356,7 +1356,7 @@ export default function (self) {
     }
   };
   /**
-   * Get a column group at grid pixel coordinate x and y.
+   * Get a row group at grid pixel coordinate x and y.
    * @memberof canvasDatagrid
    * @name getRowGroupAt
    * @method

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -1337,6 +1337,7 @@ export default function (self) {
     })[0];
   };
   /**
+   * Get a column group at grid pixel coordinate x and y.
    * @memberof canvasDatagrid
    * @name getColumnGroupAt
    * @method
@@ -1355,6 +1356,7 @@ export default function (self) {
     }
   };
   /**
+   * Get a column group at grid pixel coordinate x and y.
    * @memberof canvasDatagrid
    * @name getRowGroupAt
    * @method


### PR DESCRIPTION
@ndrsn Urgent patch for <https://canvas-datagrid.js.org/>

Sorry, I missed description text in two functions I wrote. They causes the tutorials feature of current document site down, because the site generator needs generate HTML by `description.innerHTML = marked(formatDocString(i.description));`.
