### PR TITLE
fix Move-selection gets 'stuck' when cursor exits grid

### DIFF
--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -455,11 +455,14 @@ export default function (self) {
     if (self.contextMenu || self.input) {
       return;
     }
+
+    // Cancel dragging action if user ventures outside grid
     if (self.draggingItem && e.which === 0) {
       self.stopFreezeMove(e);
       self.mouseup(e);
       return;
     }
+
     self.mouse = overridePos || self.getLayerPos(e);
     var ctrl =
         (e.ctrlKey || e.metaKey || self.attributes.persistantSelectionMode) &&

--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -455,6 +455,11 @@ export default function (self) {
     if (self.contextMenu || self.input) {
       return;
     }
+    if (self.draggingItem && e.which === 0) {
+      self.stopFreezeMove(e);
+      self.mouseup(e);
+      return;
+    }
     self.mouse = overridePos || self.getLayerPos(e);
     var ctrl =
         (e.ctrlKey || e.metaKey || self.attributes.persistantSelectionMode) &&


### PR DESCRIPTION
Fixes issue #.

Changes proposed in this pull request:

- Move-selection gets 'stuck' when cursor exits grid