### PR TITLE
Fix clearing data when grid is filtered

### DIFF
--- a/lib/intf.js
+++ b/lib/intf.js
@@ -314,7 +314,7 @@ export default function (self, ctor) {
         );
         const columnName = schema[boundColumnIndex].name;
 
-        self.viewData[boundRowIndex][columnName] = '';
+        self.originalData[boundRowIndex][columnName] = '';
 
         affectedCells.push([
           rowIndex,


### PR DESCRIPTION
Fixes a small bug where data is not cleared properly when gird is filtered. Instead of clearing cells in `viewData` we need to modify `originalData`.