### PR TITLE
Remove unnecessary codes in the context file of Karma

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -109,9 +109,9 @@
         This ensures all the tests will have been declared before karma tries to run them. -->
     <script>
         mocha.setup('bdd');
-        window.onload = () => {
-            mocha.run();
-        };
+        // window.onload = () => {
+        //     mocha.run();
+        // };
     </script>
     <script nomodule>
         window.__karma__.loaded();


### PR DESCRIPTION
Hi @ndrsn, I have run tests in watch mode(`npm run test:watch`) with this patch under multiple OS (Ubuntu and OSX). And all of the results are passed.

---
I mark these codes as comments because these codes cause the async test to be failed in watch mode.    
I guess these codes are duplicate with `window.__karma__.loaded()`. Then they make the async tests are run twice with the same Mocha instance.

``` javascript
window.onload = () => {
    mocha.run();
};
// Error:
// Mocha instance is currently running tests, cannot start a next test run until this one is done
```

