### PR TITLE
Dispatch column hide/unhide events

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -974,6 +974,22 @@
  * @param {canvasDatagrid.cell} e.cell The cell being moved out of.
  */
 /**
+ * Fires column(s) are being hidden
+ * @event
+ * @name canvasDatagrid#columnhide
+ * @param {object} e Event object.
+ * @param {object} e.ctx Canvas context.
+ * @param {columnIndex} e.columnIndex Index of column being hidden.
+ */
+/**
+ * Fires column(s) are being unhidden
+ * @event
+ * @name canvasDatagrid#columnunhide
+ * @param {object} e Event object.
+ * @param {object} e.ctx Canvas context.
+ * @param {columnIndex} e.columnIndex Index of column being unhidden.
+ */
+/**
  * Fires when the mouse enters a row.
  * @event
  * @name canvasDatagrid#rowmouseover

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -1280,17 +1280,6 @@ export default function (self, ctor) {
     };
   };
 
-  self.unhideColumns = function (orderIndex0, orderIndex1) {
-    const orders = self.orders.columns;
-    const schema = self.getSchema();
-    for (let i = orderIndex0; i <= orderIndex1; i++) {
-      const columnIndex = orders[i];
-      const s = schema[columnIndex];
-      if (s && s.hidden) s.hidden = false;
-    }
-    self.refresh();
-  };
-
   self.getDomRoot = function () {
     return self.shadowRoot ? self.shadowRoot.host : self.parentNode;
   };
@@ -1522,6 +1511,7 @@ export default function (self, ctor) {
     self.intf.paste = self.paste;
     self.intf.setStyleProperty = self.setStyleProperty;
     self.intf.hideColumns = self.hideColumns;
+    self.intf.unhideColumns = self.unhideColumns;
     self.intf.hideRows = self.hideRows;
     self.intf.unhideRows = self.unhideRows;
     Object.defineProperty(self.intf, 'defaults', {

--- a/lib/intf.js
+++ b/lib/intf.js
@@ -175,6 +175,8 @@ export default function (self, ctor) {
     'cellmouseover',
     'click',
     'collapsetree',
+    'columnhide',
+    'columnunhide',
     'contextmenu',
     'copy',
     'datachanged',

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -787,8 +787,13 @@ export default function (self) {
       if (columnIndex >= 0 && !schema[columnIndex].hidden) {
         hiddenColumns.push(columnIndex);
         schema[columnIndex].hidden = true;
+
+        self.dispatchEvent('columnhide', {
+          columnIndex,
+        });
       }
     }
+
     if (hiddenColumns.length > 0) {
       self.setStorageData();
       setTimeout(function () {
@@ -816,7 +821,13 @@ export default function (self) {
       const columnIndex = orders[i];
       const s = schema[columnIndex];
 
-      if (s && s.hidden) s.hidden = false;
+      if (s && s.hidden) {
+        s.hidden = false;
+
+        self.dispatchEvent('columnunhide', {
+          columnIndex,
+        });
+      }
     }
     self.refresh();
   };

--- a/lib/publicMethods.js
+++ b/lib/publicMethods.js
@@ -768,13 +768,14 @@ export default function (self) {
    * Hide column/columns
    * @memberof canvasDatagrid
    * @name hideColumns
+   * @method
    * @param {number} beginColumnOrderIndex
    * @param {number} [endColumnOrderIndex]
    */
   self.hideColumns = function (beginColumnOrderIndex, endColumnOrderIndex) {
     const schema = self.getSchema();
     const orders = self.orders.columns;
-    let count = 0;
+    const hiddenColumns = [];
     if (typeof endColumnOrderIndex !== 'number')
       endColumnOrderIndex = beginColumnOrderIndex;
     for (
@@ -784,21 +785,46 @@ export default function (self) {
     ) {
       const columnIndex = orders[orderIndex];
       if (columnIndex >= 0 && !schema[columnIndex].hidden) {
-        count++;
+        hiddenColumns.push(columnIndex);
         schema[columnIndex].hidden = true;
       }
     }
-    if (count > 0) {
+    if (hiddenColumns.length > 0) {
       self.setStorageData();
       setTimeout(function () {
         self.resize(true);
       }, 10);
     }
+
+    self.dispatchEvent('hidecolumns', {
+      hiddenColumns,
+    });
+  };
+  /**
+   * Unihde column/columns
+   * @memberof canvasDatagrid
+   * @name unhideColumns
+   * @method
+   * @param {number} beginColumnOrderIndex
+   * @param {number} [endColumnOrderIndex]
+   */
+  self.unhideColumns = function (beginColumnOrderIndex, endColumnOrderIndex) {
+    const orders = self.orders.columns;
+    const schema = self.getSchema();
+
+    for (let i = beginColumnOrderIndex; i <= endColumnOrderIndex; i++) {
+      const columnIndex = orders[i];
+      const s = schema[columnIndex];
+
+      if (s && s.hidden) s.hidden = false;
+    }
+    self.refresh();
   };
   /**
    * Hide rows
    * @memberof canvasDatagrid
    * @name hideRows
+   * @method
    * @param {number} beginRowIndex
    * @param {number} endRowIndex
    */
@@ -812,6 +838,7 @@ export default function (self) {
    * Unhide rows
    * @memberof canvasDatagrid
    * @name unhideRows
+   * @method
    * @param {number} beginRowIndex
    * @param {number} endRowIndex
    */
@@ -949,6 +976,7 @@ export default function (self) {
   /**
    * Add grouping
    * @param {'columns'|'rows'} groupFor
+   * @method
    * @param {number} from
    * @param {number} to
    */
@@ -1004,6 +1032,7 @@ export default function (self) {
   /**
    * Remove grouping
    * @param {Array<Array<{from:number,to:number,collapsed:boolean}>>} allGroups
+   * @method
    * @param {number} from
    * @param {number} to
    */

--- a/test/unhide-indicator.js
+++ b/test/unhide-indicator.js
@@ -10,6 +10,7 @@ import {
   makeData,
   itoa,
   savePartOfCanvasToString,
+  doAssert,
 } from './util.js';
 
 export default function () {
@@ -26,6 +27,37 @@ export default function () {
     grid.style.activeRowHeaderCellBackgroundColor = c.white;
     grid.style.activeColumnHeaderCellBackgroundColor = c.white;
   };
+
+  describe('hide/unhide column', () => {
+    it('fires columnhide event', function (done) {
+      const grid = g({ test: this.test, data: getData() });
+      grid.addEventListener('columnhide', function (event) {
+        try {
+          doAssert(event.columnIndex === 0, 'columnIndex is 0');
+        } catch (error) {
+          done(error);
+        }
+
+        done();
+      });
+      grid.hideColumns(0, 1);
+    });
+
+    it('fires columnunhide event', function (done) {
+      const grid = g({ test: this.test, data: getData() });
+      grid.addEventListener('columnunhide', function (event) {
+        try {
+          doAssert(event.columnIndex === 0, 'columnIndex is 0');
+        } catch (error) {
+          done(error);
+        }
+
+        done();
+      });
+      grid.hideColumns(0, 1);
+      grid.unhideColumns(0, 1);
+    });
+  });
 
   it('Should contain methods to hide columns', async function () {
     const grid = g({ test: this.test, data: getData() });


### PR DESCRIPTION
Dispatching events on hiding/unhiding columns is useful te be able to store grid state externally, (e.g. in settings or user profile). 

I've now made it so that an event is dispatched for each individual column being hidden even when a group of columns is being hidden. User can handle all individual events or debounce and, on last event, retrieve grid schema to figure out which columns are hidden or not.

Also moved `unhideColumns` to `publicMethods.js`, this seemed appropriate as all the other hide/unhide methods are located there.

Similar approach could be implemented for hiding / unhiding rows, will do as separate PR if agreed on this approach for columns.