### PR TITLE
Fix the bug that the canvas being cleared under unusual refresh flow

### DIFF
--- a/lib/events/index.js
+++ b/lib/events/index.js
@@ -386,9 +386,17 @@ export default function (self) {
     );
     // set canvas drawing related items
     if (!self.isChildGrid) {
-      self.canvas.width = self.width * ratio;
-      self.canvas.height = self.height * ratio;
-      self.ctx.scale(ratio, ratio);
+      const newWidth = self.width * ratio;
+      const newHeight = self.height * ratio;
+      // We need to check is settings size to canvas necessary,
+      // because settings the canvas'size will cause the canvas and its state be cleared
+      // even if the size is the same.
+      // Notes: Please don't call `self.resize()` without a subsequent call to `self.draw()`
+      if (self.canvas.width !== newWidth || self.canvas.height !== newHeight) {
+        self.canvas.width = newWidth;
+        self.canvas.height = newHeight;
+        self.ctx.scale(ratio, ratio);
+      }
     }
     // resize any open dom elements (input/textarea)
     self.resizeEditInput();


### PR DESCRIPTION
The PR is used for fixing the bug in the PR #483 

Here is a explaining of it:

1. Setting the size properties (`width`/`height`) to the canvas element can causes the canvas and its state be cleared even if the size is the same.
2. So the grid loss all rendered content if we don't draw again after a function call to `self.resize()`

Even though this PR fixes it. But I still recommend using the code `self.resize(true)` to instead of the following code:

``` javascript
self.draw(true);
self.resize();

// or:
self.resize();
self.draw(true);
```

Because it can reduces unnecessary function calls. (Because `self.draw` may also call the `self.resize` if the `checkScrollHeight` is true. https://github.com/TonyGermaneri/canvas-datagrid/blob/master/lib/draw.js#L2890-L2892)
 