### PR TITLE
Fix `formatDocString` for the uncommented elements

### DIFF
--- a/tutorials/js/main.js
+++ b/tutorials/js/main.js
@@ -35,6 +35,7 @@
         return a.name.localeCompare(b.name);
     }
     function formatDocString(str) {
+        if(typeof str !== 'string') str = '';
         str = str.replace(/\{@link +http([^\}]+)\}/ig, 'http$1');
         str = str.replace(/\{@link ([^\}]+)\}/ig, '<a href="#$1">$1</a>');
         str = str.replace(/`([^`}]+)`/ig, '<span class="inline-code">$1</span>');


### PR DESCRIPTION
A one line patch for current document site.

The document site can still works well even we don't comment any elements(function, parameter, ...) in the jsDoc.