### PR TITLE
Fix activeColumnHeaderCell docs

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -307,8 +307,8 @@
  * @property {string} [activeCellSelectedBackgroundColor=rgba(236, 243, 255, 1)] - Style of activeCellSelectedBackgroundColor.
  * @property {string} [activeCellSelectedColor=rgba(0, 0, 0, 1)] - Style of activeCellSelectedColor.
  * @property {string} [activeCellVerticalAlignment=center] - Style of activeCellVerticalAlignment.
- * @property {string} [activeHeaderCellBackgroundColor=rgba(225, 225, 225, 1)] - Style of activeHeaderCellBackgroundColor.
- * @property {string} [activeHeaderCellColor=rgba(0, 0, 0, 1)] - Style of activeHeaderCellColor.
+ * @property {string} [activeColumnHeaderCellBackgroundColor=rgba(225, 225, 225, 1)] - Style of activeColumnHeaderCellBackgroundColor.
+ * @property {string} [activeColumnHeaderCellColor=rgba(0, 0, 0, 1)] - Style of activeColumnHeaderCellColor.
  * @property {string} [activeRowHeaderCellBackgroundColor=rgba(225, 225, 225, 1)] - Style of activeRowHeaderCellBackgroundColor.
  * @property {string} [activeRowHeaderCellColor=rgba(0, 0, 0, 1)] - Style of activeRowHeaderCellColor.
  * @property {number} [autocompleteBottomMargin=60] - Style of autocompleteBottomMargin.


### PR DESCRIPTION
Fixes typos in documentation:

- Change typo `activeHeaderCellBackgroundColor` to the correct name: `activeColumnHeaderCellBackgroundColor`
- Change typo `activeHeaderCellColor` to the correct name: `activeColumnHeaderCellColor`

I was struggling with getting it to work until I noticed that the documentation is wrong on that part.

See defaults file: https://github.com/TonyGermaneri/canvas-datagrid/blob/master/lib/defaults.js