### PR TITLE
Add class name to allow targeting context menu by CSS

### DIFF
--- a/lib/dom.js
+++ b/lib/dom.js
@@ -755,6 +755,7 @@ export default function (self) {
       Object.keys(css[className]).map(function (prop) {
         el.style[prop] = css[className][prop];
       });
+      el.className = className;
     }
     return;
   };


### PR DESCRIPTION
Write className directly to created element so that it could be targeted by CSS.

Issue:
- At the moment, context menu is built manually by DOM manipulation. Suggested to add a class name to each created element to allow further manipulation.
- One example would be adding padding to context menu items, which is not possible at the moment due to missing property.
- This also should engage GPU optimizations for properties stored in CSS, while inline styles from JS will take precedence over the CSS in case of a conflict.

Changes proposed in this pull request:
- Extended dom.js to simply overwrite className - right now it is not used anywhere and should be a simple and non-breaking addition.