### PR TITLE
On copy, only include data from rows that are in the actual selection

### DIFF
--- a/lib/selections/index.js
+++ b/lib/selections/index.js
@@ -546,9 +546,10 @@ export default function (self) {
    */
   self.copySelectedCellsToClipboard = (clipboardData) => {
     const isNeat = areSelectionsNeat(self.selections);
-    const data = self.getSelectedData();
+    const selectedData = self.getSelectedData();
+    const data = selectedData.filter((row) => row != null);
+
     if (data.length > 0) {
-      // TODO: improve these two creating string method
       const textString = createTextString(data, isNeat);
       const htmlString = createHTMLString(data, isNeat);
 

--- a/test/editing.js
+++ b/test/editing.js
@@ -271,6 +271,59 @@ export default function () {
         'Expected html text to be copied',
       );
     });
+    it('only selected cells onto simulated clipboard', function (done) {
+      // Ensure padding of rows not in selection is removed before placing data on clipboard.
+      const data = [
+        {
+          d: 'Text with, a comma 1',
+          e: 'Text that has no comma in in 1',
+        },
+        {
+          d: 'Text with, a comma 2',
+          e: 'Text that has no comma in in 2',
+        },
+      ];
+
+      const grid = g({
+        test: this.test,
+        data,
+      });
+
+      grid.selectArea({ top: 1, left: 1, bottom: 1, right: 1 });
+      grid.focus();
+
+      const textResult = `Text that has no comma in in 2`;
+      const htmlResult =
+        '<table><tr><td>Text that has no comma in in 2</td></tr></table>';
+      const jsonResult = JSON.stringify([
+        {
+          e: 'Text that has no comma in in 2',
+        },
+      ]);
+
+      grid.copy(new Object(fakeClipboardEvent));
+      const { clipboardData } = fakeClipboardEvent;
+      console.log(textResult);
+      console.log(clipboardData.data);
+      doAssert(
+        clipboardData.data['text/plain'] === textResult,
+        'Expected plain text to be copied',
+      );
+      doAssert(
+        clipboardData.data['text/html'] === htmlResult,
+        'Expected html to be copied',
+      );
+      doAssert(
+        clipboardData.data['text/csv'] === textResult,
+        'Expected csv text to be copied',
+      );
+      doAssert(
+        clipboardData.data['application/json'] === jsonResult,
+        'Expected json to be copied',
+      );
+
+      done();
+    });
   });
   it('Should paste a value from the clipboard into a cell', function (done) {
     var grid = g({


### PR DESCRIPTION
This PR solves an issue when copying data while having rows above the selection that aren't selected. You can see that rows above the selection lead to new lines in the `textString` that is put on the clipboard:

![2023-04-28 17 27 37](https://user-images.githubusercontent.com/101284/235194827-940294c3-772f-42e5-8103-04f382c10876.gif)

Null values in the sparse array returned by `getSelectedData` are filtered out before data is transformed to text, html, csv or json string.