### PR TITLE
docs: Update docs.js with missing types

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -401,9 +401,12 @@
  * @property {number} [gridBorderWidth=1] - Style of gridBorderWidth.
  * @property {string} [groupIndicatorColor=rgba(155, 155, 155, 1)'] - Foreground color of the group indicator(icon).
  * @property {string} [groupIndicatorBackgroundColor=rgba(255, 255, 255, 1)'] - Background color of the group indicator(icon).
- * @property {string} [columnHeaderCellCapBackgroundColor=rgba(240, 240, 240, 1)] - Style of columnHeaderCellBackgroundColor.
- * @property {string} [columnHeaderCellCapBorderColor=rgba(172, 172, 172, 1)] - Style of columnHeaderCellBackgroundColor.
- * @property {number} [columnHeaderCellCapBorderWidth=1] - Style of columnHeaderCellBackgroundColor.
+ * @property {string} [columnHeaderCellBackgroundColor=rgba(240, 240, 240, 1)] - Style of columnHeaderCellBackgroundColor.
+ * @property {string} [columnHeaderCellBorderColor=rgba(172, 172, 172, 1)] - Style of columnHeaderCellBackgroundColor.
+ * @property {number} [columnHeaderCellBorderWidth=1] - Style of columnHeaderCellBackgroundColor.
+ * @property {string} [columnHeaderCellCapBackgroundColor=rgba(240, 240, 240, 1)] - Style of columnHeaderCellCapBackgroundColor.
+ * @property {string} [columnHeaderCellCapBorderColor=rgba(172, 172, 172, 1)] - Style of columnHeaderCellCapBackgroundColor.
+ * @property {number} [columnHeaderCellCapBorderWidth=1] - Style of columnHeaderCellCapBackgroundColor.
  * @property {string} [columnHeaderCellBorderColor=rgba(152, 152, 152, 1)] - Style of columnHeaderCellBorderColor.
  * @property {number} [columnHeaderCellBorderWidth=0.25] - Style of columnHeaderCellBorderWidth.
  * @property {string} [columnHeaderCellColor=rgba(50, 50, 50, 1)] - Style of columnHeaderCellColor.
@@ -427,6 +430,7 @@
  * @property {number} [columnHeaderOrderByArrowWidth=13] - Style of columnHeaderOrderByArrowWidth.
  * @property {number} [rowHeaderCellWidth=57] - Style of rowHeaderCellWidth.
  * @property {number} [minColumnWidth=45] - Style of minColumnWidth.
+ * @property {(number|string)} [height=auto] - Style of height.
  * @property {number} [minHeight=24] - Style of minHeight.
  * @property {number} [minRowHeight=24] - Style of minRowHeight.
  * @property {string} [name=default] - Style of name.
@@ -496,6 +500,7 @@
  * @property {number} [frozenMarkerWidth=1] - Style of frozenMarkerWidth.
  * @property {string} [overflowY=auto] - When set to hidden, vertical scroll bar will be hidden.  When set to auto vertical scroll bar will appear when data overflows the height.  When set to scroll the vertical scrollbar will always be visible.
  * @property {string} [overflowX=auto] - When set to hidden, horizontal scroll bar will be hidden.  When set to auto horizontal scroll bar will appear when data overflows the width.  When set to scroll the horizontal scrollbar will always be visible.
+ * @property {(number|string)} [width=auto] - Style of width.
 
  ['', 'normal'],
  */


### PR DESCRIPTION
add type docs for: 
• style.columnHeaderCellBackgroundColor
• style.columnHeaderCellBorderColor
• style.columnHeaderCellBorderWidth
• style.height
• style.width

fix wrong doc comments for 
• columnHeaderCellCapBackgroundColor
• columnHeaderCellCapBackgroundColor
• columnHeaderCellCapBorderColor