### PR TITLE
Moving Demos to examples folder

### DIFF
--- a/docs/docs/examples/46-vue-demo.mdx
+++ b/docs/docs/examples/46-vue-demo.mdx
@@ -2,11 +2,9 @@
 title: Vue Demo
 ---
 
-import siteConfig from '/docusaurus.config/js';
-
 <SandpackEditor>
 
-```vue 
+```js 
 
 Vue.config.ignoredElements = ['canvas-datagrid'];
 new Vue({

--- a/docs/docs/examples/46-vue-demo.mdx
+++ b/docs/docs/examples/46-vue-demo.mdx
@@ -1,3 +1,13 @@
+---
+title: Vue Demo
+---
+
+import siteConfig from '/docusaurus.config/js';
+
+<SandpackEditor>
+
+```vue 
+
 Vue.config.ignoredElements = ['canvas-datagrid'];
 new Vue({
     el: '#app',
@@ -11,3 +21,6 @@ new Vue({
         }
     }
 });
+```
+
+</SandpackEditor>

--- a/docs/docs/examples/47-Webpack3-AMD.mdx
+++ b/docs/docs/examples/47-Webpack3-AMD.mdx
@@ -3,7 +3,8 @@ title: Webpack3 AMD Demo
 ---
 
 <SandpackEditor>
-```amd 
+
+```js 
 
 require(['../dist/canvas-datagrid.debug.js'], function (dataGrid) {
     'use strict';

--- a/docs/docs/examples/47-Webpack3-AMD.mdx
+++ b/docs/docs/examples/47-Webpack3-AMD.mdx
@@ -1,4 +1,10 @@
-/*jslint browser: true */
+---
+title: Webpack3 AMD Demo
+---
+
+<SandpackEditor>
+```amd 
+
 require(['../dist/canvas-datagrid.debug.js'], function (dataGrid) {
     'use strict';
     var grid = dataGrid({
@@ -20,3 +26,6 @@ require(['../dist/canvas-datagrid.debug.js'], function (dataGrid) {
     });
     grid.data = [{a: 0, b: 1, c: 2}];
 });
+```
+
+</SandpackEditor>

--- a/docs/docs/examples/48-largeArrays.mdx
+++ b/docs/docs/examples/48-largeArrays.mdx
@@ -1,3 +1,11 @@
+---
+title:  Large Arrays
+---
+
+<SandpackEditor>
+
+```js
+
 /*jslint browser: true*/
 /*globals canvasDatagrid: false*/
 function g() {
@@ -20,3 +28,7 @@ function g() {
     grid.schema = schema;
     grid.data = data;
 }
+
+```
+
+</SandpackEditor>

--- a/docs/docs/examples/49-sparkline.mdx
+++ b/docs/docs/examples/49-sparkline.mdx
@@ -1,3 +1,9 @@
+---
+title: Sparkline Demo
+---
+
+<SandpackEditor>
+```js
 /*jslint browser: true*/
 /*globals canvasDatagrid: false*/
 document.addEventListener('DOMContentLoaded', function () {
@@ -144,3 +150,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     getData(true);
 });
+
+
+```
+</SandpackEditor>

--- a/docs/docs/examples/49-sparkline.mdx
+++ b/docs/docs/examples/49-sparkline.mdx
@@ -3,6 +3,7 @@ title: Sparkline Demo
 ---
 
 <SandpackEditor>
+
 ```js
 /*jslint browser: true*/
 /*globals canvasDatagrid: false*/

--- a/docs/docs/examples/50-react-demo.mdx
+++ b/docs/docs/examples/50-react-demo.mdx
@@ -1,3 +1,10 @@
+---
+title: React Demo
+---
+
+<SandpackEditor>
+```React
+
 /*jslint browser: true, es6: true*/
 class CanvasDatagrid extends React.Component {
     constructor(props) {
@@ -64,3 +71,7 @@ function getRandomData() {
 }
 var grid = React.createElement(GenerateRandomDataButton, {});
 ReactDOM.render(grid, document.getElementById('root'));
+
+
+```
+</SandpackEditor>

--- a/docs/docs/examples/50-react-demo.mdx
+++ b/docs/docs/examples/50-react-demo.mdx
@@ -3,7 +3,8 @@ title: React Demo
 ---
 
 <SandpackEditor>
-```React
+
+```js
 
 /*jslint browser: true, es6: true*/
 class CanvasDatagrid extends React.Component {

--- a/docs/docs/examples/51-xhr-demo.mdx
+++ b/docs/docs/examples/51-xhr-demo.mdx
@@ -1,3 +1,11 @@
+---
+title: XHR Demo 
+---
+
+<SandpackEditor>
+
+```js
+
 /*jslint browser: true*/
 /*globals canvasDatagrid: false*/
 function demo() {
@@ -128,3 +136,6 @@ function demo() {
     dataAdapter(0, 100, updateLocalCache);
 }
 document.addEventListener('DOMContentLoaded', demo);
+
+```
+</SandpackEditor>


### PR DESCRIPTION
Had to wrap code in sandpack editor to move to examples folder.  Removed js files to stay organized, can copy paste code back into js if needed.

Fixes issue #.

Changes proposed in this pull request:

- 
- 
- 
