### PR TITLE
feat: Add clearRect before draw background.

### DIFF
--- a/lib/draw.js
+++ b/lib/draw.js
@@ -1942,6 +1942,7 @@ export default function (self) {
     function drawBackground() {
       radiusRect(0, 0, w, h, 0);
       self.ctx.clip();
+      self.ctx.clearRect(0, 0, w, h);
       self.ctx.fillStyle = self.style.gridBackgroundColor;
       fillRect(0, 0, w, h);
     }


### PR DESCRIPTION
When the background color is set with a transparency parameter (such as "transparent" or when the fourth parameter of rgba is not 1), the canvas retains previously drawn content.

Reproduction steps:
1. set `gridBackgroundColor` to `"transparent"`
2. Set the grid.data array to a new array that its length shorter than it was previously.
 
